### PR TITLE
Unit tests for GraphQLClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3383,6 +3383,16 @@
         "jest-util": "^24.0.0"
       }
     },
+    "jest-fetch-mock": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.1.tgz",
+      "integrity": "sha512-/E0I80zMRTTExfM7QQZsqizT31EMHCBnqACERd2QR+7riSgta3OcHF3RzakukzQ4o3oEyIi6OleB3PAU6ArgDg==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^2.2.2",
+        "promise-polyfill": "^7.1.1"
+      }
+    },
     "jest-get-type": {
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.0.0.tgz",
@@ -4582,6 +4592,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
       "dev": true
     },
     "prompts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-jest": "24.1.0",
     "husky": "1.3.1",
     "jest": "24.1.0",
+    "jest-fetch-mock": "2.1.1",
     "prettier": "1.16.4",
     "pretty-quick": "1.10.0",
     "react": "16.8.2",
@@ -45,6 +46,10 @@
     }
   },
   "jest": {
+    "automock": false,
+    "setupFiles": [
+      "./test/setup.js"
+    ],
     "setupFilesAfterEnv": [
       "react-testing-library/cleanup-after-each"
     ]

--- a/src/GraphQLClient.js
+++ b/src/GraphQLClient.js
@@ -1,6 +1,10 @@
 class GraphQLClient {
-  constructor(config) {
+  constructor(config = {}) {
     // validate config
+    if (!config.url) {
+      throw new Error('GraphQLClient: config.url is required');
+    }
+
     if (config.fetch && typeof config.fetch !== 'function') {
       throw new Error('GraphQLClient: config.fetch must be a function');
     }
@@ -89,7 +93,7 @@ class GraphQLClient {
     };
   }
 
-  async request(operation, options) {
+  async request(operation, options = {}) {
     let result;
 
     try {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,1 @@
+global.fetch = require('jest-fetch-mock');

--- a/test/unit/GraphQLClient.test.js
+++ b/test/unit/GraphQLClient.test.js
@@ -219,7 +219,10 @@ describe('GraphQLClient', () => {
       const client = new GraphQLClient({ ...validConfig });
       fetch.mockResponseOnce(JSON.stringify({ data: 'data' }));
       await client.request({ query: TEST_QUERY });
-      expect(fetch.mock.calls[0][0]).toBe(validConfig.url);
+
+      const actual = fetch.mock.calls[0][0];
+      const expected = validConfig.url;
+      expect(actual).toBe(expected);
     });
 
     it('applies the configured headers', async () => {
@@ -227,7 +230,10 @@ describe('GraphQLClient', () => {
       const client = new GraphQLClient({ ...validConfig, headers });
       fetch.mockResponseOnce(JSON.stringify({ data: 'data' }));
       await client.request({ query: TEST_QUERY });
-      expect(fetch.mock.calls[0][1].headers['My-Header']).toBe('hello');
+
+      const actual = fetch.mock.calls[0][1].headers['My-Header'];
+      const expected = 'hello';
+      expect(actual).toBe(expected);
     });
 
     it('sends the provided operation query, variables and name', async () => {
@@ -239,7 +245,10 @@ describe('GraphQLClient', () => {
         operationName: 'test'
       };
       await client.request(operation);
-      expect(fetch.mock.calls[0][1].body).toBe(JSON.stringify(operation));
+
+      const actual = fetch.mock.calls[0][1].body;
+      const expected = JSON.stringify(operation);
+      expect(actual).toBe(expected);
     });
 
     it('handles & returns fetch errors', async () => {

--- a/test/unit/GraphQLClient.test.js
+++ b/test/unit/GraphQLClient.test.js
@@ -1,5 +1,293 @@
+import fetchMock from 'jest-fetch-mock';
 import { GraphQLClient } from '../../src';
 
+const validConfig = {
+  url: 'https://my.graphql.api'
+};
+
+const TEST_QUERY = `query Test($limit: Int) {
+  tests(limit: $limit) {
+    id
+  }
+}`;
+
 describe('GraphQLClient', () => {
-  it('runs a test', () => {});
+  describe('when insantiated', () => {
+    it('throws if no url provided', () => {
+      expect(() => {
+        new GraphQLClient();
+      }).toThrow('GraphQLClient: config.url is required');
+    });
+
+    it('throws if fetch is not a function', () => {
+      expect(() => {
+        new GraphQLClient({ ...validConfig, fetch: 'fetch!' });
+      }).toThrow('GraphQLClient: config.fetch must be a function');
+    });
+
+    it('throws if fetch is not present or polyfilled', () => {
+      const oldFetch = global.fetch;
+      global.fetch = null;
+      expect(() => {
+        new GraphQLClient(validConfig);
+      }).toThrow(
+        'GraphQLClient: fetch must be polyfilled or passed in new GraphQLClient({ fetch })'
+      );
+      global.fetch = oldFetch;
+    });
+
+    it('assigns config.cache to an instance property', () => {
+      const cache = { get: 'get', set: 'set' };
+      const client = new GraphQLClient({ ...validConfig, cache });
+      expect(client.cache).toBe(cache);
+    });
+
+    it('assigns config.headers to an instance property', () => {
+      const headers = { 'My-Header': 'hello' };
+      const client = new GraphQLClient({ ...validConfig, headers });
+      expect(client.headers).toBe(headers);
+    });
+
+    it('assigns config.ssrMode to an instance property', () => {
+      const client = new GraphQLClient({ ...validConfig, ssrMode: true });
+      expect(client.ssrMode).toBe(true);
+    });
+
+    it('assigns config.url to an instance property', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      expect(client.url).toBe(validConfig.url);
+    });
+
+    it('assigns config.fetch to an instance property', () => {
+      const myFetch = jest.fn();
+      const client = new GraphQLClient({ ...validConfig, fetch: myFetch });
+      expect(client.fetch).toBe(myFetch);
+    });
+
+    it('assigns config.fetchOptions to an instance property', () => {
+      const fetchOptions = { fetch: 'options' };
+      const client = new GraphQLClient({ ...validConfig, fetchOptions });
+      expect(client.fetchOptions).toBe(fetchOptions);
+    });
+
+    it('assigns config.logErrors to an instance property', () => {
+      const logErrors = jest.fn();
+      const client = new GraphQLClient({ ...validConfig, logErrors });
+      expect(client.logErrors).toBe(logErrors);
+    });
+
+    it('assigns config.onError to an instance property', () => {
+      const onError = jest.fn();
+      const client = new GraphQLClient({ ...validConfig, onError });
+      expect(client.onError).toBe(onError);
+    });
+  });
+
+  describe('setHeader', () => {
+    it('sets the key to the value', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      client.setHeader('My-Header', 'hello');
+      expect(client.headers['My-Header']).toBe('hello');
+    });
+  });
+
+  describe('setHeaders', () => {
+    it('replaces all headers', () => {
+      const headers = { 'My-Header': 'hello ' };
+      const client = new GraphQLClient({ ...validConfig });
+      client.setHeaders(headers);
+      expect(client.headers).toBe(headers);
+    });
+  });
+
+  describe('logErrorResult', () => {
+    let logSpy, errorSpy, groupCollapsedSpy, groupEndSpy;
+
+    beforeEach(() => {
+      logSpy = spyOn(global.console, 'log');
+      errorSpy = spyOn(global.console, 'error');
+      groupCollapsedSpy = spyOn(global.console, 'groupCollapsed');
+      groupEndSpy = spyOn(global.console, 'groupEnd');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('calls onError if present', () => {
+      const onError = jest.fn();
+      const client = new GraphQLClient({ ...validConfig, onError });
+      client.logErrorResult({ result: 'result', operation: 'operation' });
+      expect(onError).toHaveBeenCalledWith({
+        result: 'result',
+        operation: 'operation'
+      });
+    });
+
+    it('logs a fetchError', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      client.logErrorResult({ result: { fetchError: 'on no fetch!' } });
+      expect(groupCollapsedSpy).toHaveBeenCalledWith('FETCH ERROR:');
+      expect(logSpy).toHaveBeenCalledWith('on no fetch!');
+      expect(groupEndSpy).toHaveBeenCalled();
+    });
+
+    it('logs an httpError', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      client.logErrorResult({ result: { httpError: 'on no http!' } });
+      expect(groupCollapsedSpy).toHaveBeenCalledWith('HTTP ERROR:');
+      expect(logSpy).toHaveBeenCalledWith('on no http!');
+      expect(groupEndSpy).toHaveBeenCalled();
+    });
+
+    it('logs all graphQLErrors', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      const graphQLErrors = ['on no GraphQL!', 'oops GraphQL!'];
+      client.logErrorResult({ result: { graphQLErrors } });
+      expect(groupCollapsedSpy).toHaveBeenCalledWith('GRAPHQL ERROR:');
+      expect(logSpy).toHaveBeenCalledWith('on no GraphQL!');
+      expect(logSpy).toHaveBeenCalledWith('oops GraphQL!');
+      expect(groupEndSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('generateResult', () => {
+    it('shows as errored if there are graphQL errors', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      const result = client.generateResult({
+        graphQLErrors: ['error 1', 'error 2']
+      });
+      expect(result.error).toBe(true);
+    });
+
+    it('shows as errored if there is a fetch error', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      const result = client.generateResult({
+        fetchError: 'fetch error'
+      });
+      expect(result.error).toBe(true);
+    });
+
+    it('shows as errored if there is an http error', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      const result = client.generateResult({
+        httpError: 'http error'
+      });
+      expect(result.error).toBe(true);
+    });
+
+    it('returns the errors & data', () => {
+      const client = new GraphQLClient({ ...validConfig });
+      const data = {
+        graphQLErrors: ['graphQL error 1', 'graphQL error 2'],
+        fetchError: 'fetch error',
+        httpError: 'http error',
+        data: 'data!'
+      };
+      const result = client.generateResult(data);
+      expect(result).toEqual({
+        error: true,
+        graphQLErrors: data.graphQLErrors,
+        fetchError: data.fetchError,
+        httpError: data.httpError,
+        data: data.data
+      });
+    });
+  });
+
+  describe('getCacheKey', () => {
+    it('returns a cache key', () => {
+      const client = new GraphQLClient({
+        ...validConfig,
+        fetchOptions: { optionOne: 1 }
+      });
+      const cacheKey = client.getCacheKey('operation', {
+        fetchOptionsOverrides: { optionTwo: 2 }
+      });
+      expect(cacheKey).toEqual({
+        operation: 'operation',
+        fetchOptions: { optionOne: 1, optionTwo: 2 }
+      });
+    });
+  });
+
+  describe('request', () => {
+    afterEach(() => {
+      fetch.resetMocks();
+    });
+
+    it('sends the request to the configured url', async () => {
+      const client = new GraphQLClient({ ...validConfig });
+      fetch.mockResponseOnce(JSON.stringify({ data: 'data' }));
+      await client.request({ query: TEST_QUERY });
+      expect(fetch.mock.calls[0][0]).toBe(validConfig.url);
+    });
+
+    it('applies the configured headers', async () => {
+      const headers = { 'My-Header': 'hello' };
+      const client = new GraphQLClient({ ...validConfig, headers });
+      fetch.mockResponseOnce(JSON.stringify({ data: 'data' }));
+      await client.request({ query: TEST_QUERY });
+      expect(fetch.mock.calls[0][1].headers['My-Header']).toBe('hello');
+    });
+
+    it('sends the provided operation query, variables and name', async () => {
+      const client = new GraphQLClient({ ...validConfig });
+      fetch.mockResponseOnce(JSON.stringify({ data: 'data' }));
+      const operation = {
+        query: TEST_QUERY,
+        variables: { limit: 1 },
+        operationName: 'test'
+      };
+      await client.request(operation);
+      expect(fetch.mock.calls[0][1].body).toBe(JSON.stringify(operation));
+    });
+
+    it('handles & returns fetch errors', async () => {
+      const client = new GraphQLClient({ ...validConfig });
+      client.logErrorResult = jest.fn();
+      const error = new Error('Oops fetch!');
+      fetch.mockRejectOnce(error);
+      const res = await client.request({ query: TEST_QUERY });
+      expect(res.fetchError).toBe(error);
+    });
+
+    it('handles & returns http errors', async () => {
+      const client = new GraphQLClient({ ...validConfig });
+      client.logErrorResult = jest.fn();
+      fetch.mockResponseOnce('Denied!', {
+        status: 403
+      });
+      const res = await client.request({ query: TEST_QUERY });
+      expect(res.httpError).toEqual({
+        status: 403,
+        statusText: 'Forbidden',
+        body: 'Denied!'
+      });
+    });
+
+    it('returns valid responses', async () => {
+      const client = new GraphQLClient({ ...validConfig });
+      fetch.mockResponseOnce(JSON.stringify({ data: 'data!' }));
+      const res = await client.request({ query: TEST_QUERY });
+      expect(res.data).toBe('data!');
+    });
+
+    it('returns graphql errors', async () => {
+      const client = new GraphQLClient({ ...validConfig });
+      client.logErrorResult = jest.fn();
+      fetch.mockResponseOnce(
+        JSON.stringify({ data: 'data!', errors: ['oops!'] })
+      );
+      const res = await client.request({ query: TEST_QUERY });
+      expect(res.graphQLErrors).toEqual(['oops!']);
+    });
+
+    it('will use a configured fetch implementation', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: 'data' }));
+      const client = new GraphQLClient({ ...validConfig, fetch: fetchMock });
+      await client.request({ query: TEST_QUERY });
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
 });

--- a/test/unit/GraphQLClient.test.js
+++ b/test/unit/GraphQLClient.test.js
@@ -71,9 +71,8 @@ describe('GraphQLClient', () => {
     });
 
     it('assigns config.logErrors to an instance property', () => {
-      const logErrors = jest.fn();
-      const client = new GraphQLClient({ ...validConfig, logErrors });
-      expect(client.logErrors).toBe(logErrors);
+      const client = new GraphQLClient({ ...validConfig, logErrors: true });
+      expect(client.logErrors).toBe(true);
     });
 
     it('assigns config.onError to an instance property', () => {

--- a/test/unit/GraphQLClient.test.js
+++ b/test/unit/GraphQLClient.test.js
@@ -12,7 +12,7 @@ const TEST_QUERY = `query Test($limit: Int) {
 }`;
 
 describe('GraphQLClient', () => {
-  describe('when insantiated', () => {
+  describe('when instantiated', () => {
     it('throws if no url provided', () => {
       expect(() => {
         new GraphQLClient();


### PR DESCRIPTION
Part of #9 

Add test coverage for `GraphQLClient`

``` PASS  test/unit/GraphQLClient.test.js
  GraphQLClient
    when instantiated
      ✓ throws if no url provided (10ms)
      ✓ throws if fetch is not a function (1ms)
      ✓ throws if fetch is not present or polyfilled (1ms)
      ✓ assigns config.cache to an instance property
      ✓ assigns config.headers to an instance property
      ✓ assigns config.ssrMode to an instance property
      ✓ assigns config.url to an instance property (1ms)
      ✓ assigns config.fetch to an instance property
      ✓ assigns config.fetchOptions to an instance property
      ✓ assigns config.logErrors to an instance property (1ms)
      ✓ assigns config.onError to an instance property
    setHeader
      ✓ sets the key to the value (1ms)
    setHeaders
      ✓ replaces all headers
    logErrorResult
      ✓ calls onError if present (3ms)
      ✓ logs a fetchError (2ms)
      ✓ logs an httpError
      ✓ logs all graphQLErrors (1ms)
    generateResult
      ✓ shows as errored if there are graphQL errors (1ms)
      ✓ shows as errored if there is a fetch error
      ✓ shows as errored if there is an http error
      ✓ returns the errors & data (1ms)
    getCacheKey
      ✓ returns a cache key
    request
      ✓ sends the request to the configured url (3ms)
      ✓ applies the configured headers
      ✓ sends the provided operation query, variables and name (1ms)
      ✓ handles & returns fetch errors (1ms)
      ✓ handles & returns http errors (1ms)
      ✓ returns valid responses
      ✓ returns graphql errors (1ms)
      ✓ will use a configured fetch implementation
```