### PR TITLE
Unit tests for useQuery

### DIFF
--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -1,5 +1,104 @@
-import { useQuery } from '../../src';
+import React from 'react';
+import { testHook } from 'react-testing-library';
+import { ClientContext, useQuery } from '../../src';
+
+let mockQueryReq, mockState;
+jest.mock('../../src/useClientRequest', () => () => [mockQueryReq, mockState]);
+
+let mockClient;
+const Wrapper = props => (
+  <ClientContext.Provider value={mockClient}>
+    {props.children}
+  </ClientContext.Provider>
+);
+
+const TEST_QUERY = `query Test($limit: Int) {
+  tests(limit: $limit) {
+    id
+  }
+}`;
 
 describe('useQuery', () => {
-  it('runs a test', () => {});
+  beforeEach(() => {
+    mockQueryReq = jest.fn();
+    mockState = { loading: true, cacheHit: false };
+    mockClient = {
+      ssrMode: false,
+      ssrPromises: []
+    };
+  });
+
+  afterEach(() => {
+    jest.unmock('../../src/useClientRequest');
+  });
+
+  it('returns initial state from useClientRequest & refetch', () => {
+    let state;
+    testHook(() => (state = useQuery(TEST_QUERY)), { wrapper: Wrapper });
+    expect(state).toEqual({
+      loading: true,
+      cacheHit: false,
+      refetch: expect.any(Function)
+    });
+  });
+
+  it('bypasses cache when refetch is called', () => {
+    let refetch;
+    testHook(() => ({ refetch } = useQuery(TEST_QUERY)), { wrapper: Wrapper });
+    refetch();
+    expect(mockQueryReq).toHaveBeenCalledWith({ skipCache: true });
+  });
+
+  it('sends the query on mount if no data & no error', () => {
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockQueryReq).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send the same query on mount if data is already present', () => {
+    mockState.data = { some: 'data' };
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockQueryReq).not.toHaveBeenCalled();
+  });
+
+  it('does not send the query on mount if there is already data', () => {
+    mockState.error = true;
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockQueryReq).not.toHaveBeenCalled();
+  });
+
+  it('does not send the query on mount if there is an error', () => {
+    mockState.error = true;
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockQueryReq).not.toHaveBeenCalled();
+  });
+
+  it('adds query to ssrPromises when in ssrMode if no data & no error', () => {
+    mockClient.ssrMode = true;
+    mockQueryReq.mockResolvedValueOnce('data');
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockClient.ssrPromises[0]).resolves.toBe('data');
+  });
+
+  it('does not add query to ssrPromises when in ssrMode if there is already data', () => {
+    mockState.data = { some: 'data ' };
+    mockClient.ssrMode = true;
+    mockQueryReq.mockResolvedValueOnce('data');
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockClient.ssrPromises).toHaveLength(0);
+  });
+
+  it('does not add query to ssrPromises when in ssrMode if there is an error', () => {
+    mockState.error = true;
+    mockClient.ssrMode = true;
+    mockQueryReq.mockResolvedValueOnce('data');
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(mockClient.ssrPromises).toHaveLength(0);
+  });
+
+  it('does not add query to ssrPromises when in ssrMode if ssr is overridden in options', () => {
+    mockClient.ssrMode = true;
+    mockQueryReq.mockResolvedValueOnce('data');
+    testHook(() => useQuery(TEST_QUERY, { ssr: false }), { wrapper: Wrapper });
+    expect(mockClient.ssrPromises).toHaveLength(0);
+  });
 });

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { testHook } from 'react-testing-library';
-import { ClientContext, useQuery } from '../../src';
+import { ClientContext, useQuery, useClientRequest } from '../../src';
 
-let mockQueryReq, mockState;
-jest.mock('../../src/useClientRequest', () => () => [mockQueryReq, mockState]);
+jest.mock('../../src/useClientRequest');
 
-let mockClient;
+let mockQueryReq, mockState, mockClient;
+
 const Wrapper = props => (
   <ClientContext.Provider value={mockClient}>
     {props.children}
@@ -22,6 +22,8 @@ describe('useQuery', () => {
   beforeEach(() => {
     mockQueryReq = jest.fn();
     mockState = { loading: true, cacheHit: false };
+    useClientRequest.mockReturnValue([mockQueryReq, mockState]);
+
     mockClient = {
       ssrMode: false,
       ssrPromises: []
@@ -30,6 +32,23 @@ describe('useQuery', () => {
 
   afterEach(() => {
     jest.unmock('../../src/useClientRequest');
+  });
+
+  it('calls useClientRequest with query', () => {
+    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
+    expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
+      useCache: true
+    });
+  });
+
+  it('calls useClientRequest with options', () => {
+    testHook(() => useQuery(TEST_QUERY, { useCache: false, extra: 'option' }), {
+      wrapper: Wrapper
+    });
+    expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
+      useCache: false,
+      extra: 'option'
+    });
   });
 
   it('returns initial state from useClientRequest & refetch', () => {

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -85,12 +85,6 @@ describe('useQuery', () => {
     expect(mockQueryReq).not.toHaveBeenCalled();
   });
 
-  it('does not send the query on mount if there is already data', () => {
-    mockState.error = true;
-    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
-    expect(mockQueryReq).not.toHaveBeenCalled();
-  });
-
   it('does not send the query on mount if there is an error', () => {
     mockState.error = true;
     testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });


### PR DESCRIPTION
Part of #9 

Add test coverage for `useQuery`

```
 PASS  test/unit/useQuery.test.js
  useQuery
    ✓ calls useClientRequest with query (22ms)
    ✓ calls useClientRequest with options (2ms)
    ✓ returns initial state from useClientRequest & refetch (2ms)
    ✓ bypasses cache when refetch is called (1ms)
    ✓ sends the query on mount if no data & no error (2ms)
    ✓ does not send the same query on mount if data is already present (2ms)
    ✓ does not send the query on mount if there is an error (1ms)
    ✓ adds query to ssrPromises when in ssrMode if no data & no error (3ms)
    ✓ does not add query to ssrPromises when in ssrMode if there is already data (1ms)
    ✓ does not add query to ssrPromises when in ssrMode if there is an error (1ms)
    ✓ does not add query to ssrPromises when in ssrMode if ssr is overridden in options (2ms)
    ✓ does not send the same query twice (2ms)
    ✓ sends the query again if the variables change (5ms)
    ✓ sends another query if the query changes (2ms)
```