### PR TITLE
Unit tests for useManualQuery

### DIFF
--- a/test/unit/useManualQuery.test.js
+++ b/test/unit/useManualQuery.test.js
@@ -9,10 +9,6 @@ const TEST_QUERY = `query Test($limit: Int) {
 }`;
 
 describe('useManualQuery', () => {
-  afterEach(() => {
-    jest.unmock('../../src/useClientRequest');
-  });
-
   it('calls useClientRequest with useCache set to true & options', () => {
     useManualQuery(TEST_QUERY, { option: 'option' });
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {

--- a/test/unit/useManualQuery.test.js
+++ b/test/unit/useManualQuery.test.js
@@ -1,0 +1,23 @@
+import { useManualQuery, useClientRequest } from '../../src';
+
+jest.mock('../../src/useClientRequest');
+
+const TEST_QUERY = `query Test($limit: Int) {
+  tests(limit: $limit) {
+    id
+  }
+}`;
+
+describe('useManualQuery', () => {
+  afterEach(() => {
+    jest.unmock('../../src/useClientRequest');
+  });
+
+  it('calls useClientRequest with useCache set to true & options', () => {
+    useManualQuery(TEST_QUERY, { option: 'option' });
+    expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
+      useCache: true,
+      option: 'option'
+    });
+  });
+});

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -36,10 +36,6 @@ describe('useQuery', () => {
     };
   });
 
-  afterEach(() => {
-    jest.unmock('../../src/useClientRequest');
-  });
-
   it('calls useClientRequest with query', () => {
     testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {


### PR DESCRIPTION
Part of #9 

Adds a test for `useManualQuery` which is just a proxy to `useClientRequest` with `useCache=true`

```
 PASS  test/unit/useManualQuery.test.js
  useManualQuery
    ✓ calls useClientRequest with useCache set to true & options (5ms)
```