### PR TITLE
Unit tests for useMutation

### DIFF
--- a/test/unit/useMutation.test.js
+++ b/test/unit/useMutation.test.js
@@ -9,10 +9,6 @@ const TEST_QUERY = `query Test($limit: Int) {
 }`;
 
 describe('useMutation', () => {
-  afterEach(() => {
-    jest.unmock('../../src/useClientRequest');
-  });
-
   it('calls useClientRequest with options', () => {
     useMutation(TEST_QUERY, { option: 'option' });
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {

--- a/test/unit/useMutation.test.js
+++ b/test/unit/useMutation.test.js
@@ -1,0 +1,22 @@
+import { useMutation, useClientRequest } from '../../src';
+
+jest.mock('../../src/useClientRequest');
+
+const TEST_QUERY = `query Test($limit: Int) {
+  tests(limit: $limit) {
+    id
+  }
+}`;
+
+describe('useMutation', () => {
+  afterEach(() => {
+    jest.unmock('../../src/useClientRequest');
+  });
+
+  it('calls useClientRequest with options', () => {
+    useMutation(TEST_QUERY, { option: 'option' });
+    expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
+      option: 'option'
+    });
+  });
+});


### PR DESCRIPTION
Part of #9 

Adds a test for `useMutation` which is just a proxy to `useClientRequest`

```
 PASS  test/unit/useMutation.test.js
  useMutation
    ✓ calls useClientRequest with options (5ms)
```