### PR TITLE
Trigger another request if the variables or query change

### DIFF
--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -25,9 +25,7 @@ module.exports = function useQuery(query, opts = {}) {
   }
 
   React.useEffect(() => {
-    if (!state.data && !state.error) {
-      queryReq();
-    }
+    queryReq();
   }, [query, JSON.stringify(opts.variables)]);
 
   return {

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -135,11 +135,55 @@ describe('useQuery', () => {
     expect(mockQueryReq).toHaveBeenCalledTimes(2);
   });
 
+  it('sends the query again if the variables change, even if there was previously data', () => {
+    let options = { variables: { limit: 2 } };
+    const { rerender } = testHook(() => useQuery(TEST_QUERY, options), {
+      wrapper: Wrapper
+    });
+    mockState.data = { some: 'data' };
+    options.variables.limit = 3;
+    rerender();
+    expect(mockQueryReq).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends the query again if the variables change, even if there was previously an error', () => {
+    let options = { variables: { limit: 2 } };
+    const { rerender } = testHook(() => useQuery(TEST_QUERY, options), {
+      wrapper: Wrapper
+    });
+    mockState.error = true;
+    options.variables.limit = 3;
+    rerender();
+    expect(mockQueryReq).toHaveBeenCalledTimes(2);
+  });
+
   it('sends another query if the query changes', () => {
     let query = TEST_QUERY;
     const { rerender } = testHook(() => useQuery(query), {
       wrapper: Wrapper
     });
+    query = ANOTHER_TEST_QUERY;
+    rerender();
+    expect(mockQueryReq).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends the query again if the query changes, even if there was previously data', () => {
+    let query = TEST_QUERY;
+    const { rerender } = testHook(() => useQuery(query), {
+      wrapper: Wrapper
+    });
+    mockState.data = { some: 'data' };
+    query = ANOTHER_TEST_QUERY;
+    rerender();
+    expect(mockQueryReq).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends the query again if the query changes, even if there was previously an error', () => {
+    let query = TEST_QUERY;
+    const { rerender } = testHook(() => useQuery(query), {
+      wrapper: Wrapper
+    });
+    mockState.error = true;
     query = ANOTHER_TEST_QUERY;
     rerender();
     expect(mockQueryReq).toHaveBeenCalledTimes(2);

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -75,18 +75,6 @@ describe('useQuery', () => {
     expect(mockQueryReq).toHaveBeenCalledTimes(1);
   });
 
-  it('does not send the same query on mount if data is already present', () => {
-    mockState.data = { some: 'data' };
-    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
-    expect(mockQueryReq).not.toHaveBeenCalled();
-  });
-
-  it('does not send the query on mount if there is an error', () => {
-    mockState.error = true;
-    testHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper });
-    expect(mockQueryReq).not.toHaveBeenCalled();
-  });
-
   it('adds query to ssrPromises when in ssrMode if no data & no error', () => {
     mockClient.ssrMode = true;
     mockQueryReq.mockResolvedValueOnce('data');


### PR DESCRIPTION
### The issue

See #35 

The following tests are failing because there should be a second request that currently isn't being sent
```
✕ sends the query again if the variables change, even if there was previously data (3ms)
✕ sends the query again if the variables change, even if there was previously an error (3ms)
✕ sends the query again if the query changes, even if there was previously data (2ms)
✕ sends the query again if the query changes, even if there was previously an error (2ms)
```

### The fix
Remove the `state.data` & `state.error` check inside the `useQuery` effect. It already has conditional checks to make sure it only fires if `query` or `opts.variables` have changed. 

```
✓ sends the query again if the variables change, even if there was previously data (3ms)
✓ sends the query again if the variables change, even if there was previously an error (2ms)
✓ sends the query again if the query changes, even if there was previously data (2ms)
✓ sends the query again if the query changes, even if there was previously an error (2ms)
```