### PR TITLE
Fix initial loading state with useMutation and add optmization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,5 +11,6 @@ module.exports = {
   useManualQuery: (query, options) =>
     useClientRequest(query, { useCache: true, ...options }),
   // alias
-  useMutation: useClientRequest
+  useMutation: (query, options) =>
+    useClientRequest(query, { isMutation: true, ...options })
 };

--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -53,7 +53,7 @@ function useClientRequest(query, initialOpts = {}) {
   const [state, dispatch] = React.useReducer(reducer, {
     ...intialCacheHit,
     cacheHit: !!intialCacheHit,
-    loading: !intialCacheHit
+    loading: initialOpts.isMutation ? false : !intialCacheHit
   });
 
   // arguments to fetchData override the useClientRequest arguments

--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -10,6 +10,9 @@ const actionTypes = {
 function reducer(state, action) {
   switch (action.type) {
     case actionTypes.LOADING:
+      if (state.loading) {
+        return state; // saves a render cycle as state is the same
+      }
       return {
         ...state,
         loading: true

--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -51,12 +51,12 @@ function useClientRequest(query, initialOpts = {}) {
   };
 
   const cacheKey = client.getCacheKey(operation, initialOpts);
-  const intialCacheHit =
+  const initialCacheHit =
     initialOpts.skipCache || !client.cache ? null : client.cache.get(cacheKey);
   const [state, dispatch] = React.useReducer(reducer, {
-    ...intialCacheHit,
-    cacheHit: !!intialCacheHit,
-    loading: initialOpts.isMutation ? false : !intialCacheHit
+    ...initialCacheHit,
+    cacheHit: !!initialCacheHit,
+    loading: initialOpts.isMutation ? false : !initialCacheHit
   });
 
   // arguments to fetchData override the useClientRequest arguments

--- a/test/unit/useClientRequest.test.js
+++ b/test/unit/useClientRequest.test.js
@@ -69,6 +69,21 @@ describe('useClientRequest', () => {
       });
       expect(state).toEqual({ cacheHit: false, loading: true });
     });
+
+    it('sets loading to false if isMutation is passed in', () => {
+      let fetchData, state;
+      testHook(
+        () =>
+          ([fetchData, state] = useClientRequest(TEST_QUERY, {
+            isMutation: true
+          })),
+        {
+          wrapper: Wrapper
+        }
+      );
+      expect(fetchData).toEqual(expect.any(Function));
+      expect(state).toEqual({ cacheHit: false, loading: false });
+    });
   });
 
   describe('fetchData', () => {

--- a/test/unit/useMutation.test.js
+++ b/test/unit/useMutation.test.js
@@ -9,9 +9,10 @@ const TEST_QUERY = `query Test($limit: Int) {
 }`;
 
 describe('useMutation', () => {
-  it('calls useClientRequest with options', () => {
+  it('calls useClientRequest with options and isMutation set to true', () => {
     useMutation(TEST_QUERY, { option: 'option' });
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
+      isMutation: true,
       option: 'option'
     });
   });


### PR DESCRIPTION
This makes sure that `loading` is set to false when `useMutation` is called. It causes issues having `loading` default to true for a mutation because it doesn't actually send the request until the consumer calls the returned method. 

This is probably considered a breaking change? @bmullan91 / @jackdclark 

Another small thing in this PR is an additional check to avoid making a new state object if we don't need to, this means react won't try to render wastefully.