### PR TITLE
Pagination with useQuery fetchMore

### DIFF
--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -57,7 +57,7 @@ function useClientRequest(query, initialOpts = {}) {
   });
 
   // arguments to fetchData override the useClientRequest arguments
-  async function fetchData(newOpts) {
+  async function fetchData(newOpts, updateResult) {
     const revisedOpts = {
       ...initialOpts,
       ...newOpts
@@ -85,7 +85,11 @@ function useClientRequest(query, initialOpts = {}) {
     }
 
     dispatch({ type: actionTypes.LOADING });
-    const result = await client.request(revisedOperation, revisedOpts);
+    let result = await client.request(revisedOperation, revisedOpts);
+
+    if (result.data && updateResult && typeof updateResult === 'function') {
+      result.data = updateResult(state.data, result.data);
+    }
 
     if (revisedOpts.useCache && client.cache) {
       client.cache.set(revisedCacheKey, result);


### PR DESCRIPTION
Similar to the [`fetchMore` in apollo](https://www.apollographql.com/docs/react/advanced/caching.html#fetchMore), return a `fetchMore` function from `useQuery` that allows you to pass in new options & control how the resulting data merges with the previous data.

### Example usage:

```jsx
export default function PostList () {
  const { loading, error, data, fetchMore } = useQuery(allPostsQuery, {
    variables: { skip: 0, first: 10 }
  })

  if (error) return <ErrorMessage message='Error loading posts.' />
  if (loading && !data) return <div>Loading</div>

  const { allPosts, _allPostsMeta } = data

  const areMorePosts = allPosts.length < _allPostsMeta.count

  return (
    <section>
      <ul>
        {allPosts.map(post => (
          <li key={post.id}>
            <a href={post.url}>{post.title}</a>
          </li>
        ))}
      </ul>
      {areMorePosts && (
        <button onClick={() => loadMorePosts(allPosts, fetchMore)}>
          {loading && !data ? 'Loading...' : 'Show More'}
        </button>
      )}
    </section>
  )
}

function loadMorePosts (allPosts, fetchMore) {
  fetchMore({
    variables: { skip: allPosts.length }
  }, (prevResult, result) => ({
    ...result,
    allPosts: [...prevResult.allPosts, result.allPosts]
  }))
}
```
