### PR TITLE
Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ const { loading, error, data, refetch, cacheHit, ...errors } = useQuery(QUERY);
 - `loading`: Boolean - `true` if the query is in flight
 - `error`: Boolean - `true` if `fetchError` or `httpError` or `graphQLErrors` has been set
 - `data`: Object - the result of your GraphQL query
-- `refetch(options)`: Function - useful when refetching the same query after a mutation; NOTE this presets `skipCache=true`
-  - options: Object - options that will be merged into the `options` that were passed into `useQuery` (see above).
+- `refetch(options)`: Function - useful when refetching the same query after a mutation; NOTE this presets `skipCache=true` & will bypass the `options.updateData` function that was passed into `useQuery`. You can pass a new `updateData` into `refetch` if necessary.
+  - `options`: Object - options that will be merged into the `options` that were passed into `useQuery` (see above).
 - `cacheHit`: Boolean - `true` if the query result came from the cache, useful for debugging
 - `fetchError`: Object - Set if an error occured during the `fetch` call
 - `httpError`: Object - Set if an error response was returned from the server

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ This is a custom hook that takes care of fetching your query and storing the res
   - `skipCache`: Boolean - defaults to `false`; If `true` it will by-pass the cache and fetch, but the result will then be cached for subsequent calls. Note the `refetch` function will do this automatically
   - `ssr`: Boolean - defaults to `true`. Set to `false` if you wish to skip this query during SSR
   - `fetchOptionsOverrides`: Object - Specific overrides for this query. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) for info on what options can be passed
+  - `updateResult(previousResult, result)`: Function - Custom handler for merging previous & new query results; return value will replace `data` in `useQuery` return value
+    - `previousResult`: Previous GraphQL query or `updateResult` result
+    - `result`: New GraphQL query result
 
 ### `useQuery` return value
 
@@ -198,6 +201,8 @@ const { loading, error, data, refetch, cacheHit, ...errors } = useQuery(QUERY);
 - `error`: Boolean - `true` if `fetchError` or `httpError` or `graphQLErrors` has been set
 - `data`: Object - the result of your GraphQL query
 - `refetch`: Function - useful when refetching the same query after a mutation; NOTE this presets `skipCache=true`
+- `fetchMore(options)`: Function - send the same query with updated options, useful for pagination.
+  - `options`: Object - options that will be merged into the `options` that were passed into `useQuery` (see above).
 - `cacheHit`: Boolean - `true` if the query result came from the cache, useful for debugging
 - `fetchError`: Object - Set if an error occured during the `fetch` call
 - `httpError`: Object - Set if an error response was returned from the server

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ This is a custom hook that takes care of fetching your query and storing the res
   - `skipCache`: Boolean - defaults to `false`; If `true` it will by-pass the cache and fetch, but the result will then be cached for subsequent calls. Note the `refetch` function will do this automatically
   - `ssr`: Boolean - defaults to `true`. Set to `false` if you wish to skip this query during SSR
   - `fetchOptionsOverrides`: Object - Specific overrides for this query. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) for info on what options can be passed
-  - `updateResult(previousResult, result)`: Function - Custom handler for merging previous & new query results; return value will replace `data` in `useQuery` return value
-    - `previousResult`: Previous GraphQL query or `updateResult` result
-    - `result`: New GraphQL query result
+  - `updateData(previousData, data)`: Function - Custom handler for merging previous & new query results; return value will replace `data` in `useQuery` return value
+    - `previousData`: Previous GraphQL query or `updateData` result
+    - `data`: New GraphQL query result
 
 ### `useQuery` return value
 
@@ -395,8 +395,8 @@ Here is an example where we append each paginated query to the bottom of the cur
 import { React, useState } from 'react';
 import { useQuery } from 'graphql-hooks';
 
-// use options.updateResult to append the new page of posts to our current list of posts
-const updateResult = (prevResult, result) => ({
+// use options.updateData to append the new page of posts to our current list of posts
+const updateData = (prevResult, result) => ({
   ...result,
   allPosts: [...prevResult.allPosts, ...result.allPosts]
 });
@@ -407,7 +407,7 @@ export default function PostList() {
   const { loading, error, data } = useQuery(
     allPostsQuery,
     { variables: { skip: skipCount, first: 10 } },
-    updateResult
+    updateData
   );
 
   if (error) return <div>There was an error!</div>;

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ function MyComponent() {
   - [useMutation](#useMutation)
 - Guides
   - [SSR](#SSR)
+  - [Pagination](#Pagination)
   - [Authentication](#Authentication)
   - [Fragments](#Fragments)
   - [Migrating from Apollo](#Migrating-from-Apollo)
@@ -200,9 +201,8 @@ const { loading, error, data, refetch, cacheHit, ...errors } = useQuery(QUERY);
 - `loading`: Boolean - `true` if the query is in flight
 - `error`: Boolean - `true` if `fetchError` or `httpError` or `graphQLErrors` has been set
 - `data`: Object - the result of your GraphQL query
-- `refetch`: Function - useful when refetching the same query after a mutation; NOTE this presets `skipCache=true`
-- `fetchMore(options)`: Function - send the same query with updated options, useful for pagination.
-  - `options`: Object - options that will be merged into the `options` that were passed into `useQuery` (see above).
+- `refetch(options)`: Function - useful when refetching the same query after a mutation; NOTE this presets `skipCache=true`
+  - options: Object - options that will be merged into the `options` that were passed into `useQuery` (see above).
 - `cacheHit`: Boolean - `true` if the query result came from the cache, useful for debugging
 - `fetchError`: Object - Set if an error occured during the `fetch` call
 - `httpError`: Object - Set if an error response was returned from the server
@@ -313,6 +313,130 @@ The `options` object that can be passed either to `useMutation(mutation, options
 ### SSR
 
 See [graphql-hooks-ssr](https://github.com/nearform/graphql-hooks-ssr) for an in depth guide.
+
+### Pagination
+
+[GraphQL Pagination](https://graphql.org/learn/pagination/) can be implemented in various ways and it's down to the consumer to decide how to deal with the resulting data from paginated queries. Take the following query as an example of offset pagination:
+
+```javascript
+export const allPostsQuery = `
+  query allPosts($first: Int!, $skip: Int!) {
+    allPosts(orderBy: createdAt_DESC, first: $first, skip: $skip) {
+      id
+      title
+      votes
+      url
+      createdAt
+    }
+    _allPostsMeta {
+      count
+    }
+  }
+`;
+```
+
+In this query, the `$first` variable is used to limit the number of posts that are returned and the `$skip` variable is used to determine the offset at which to start. We can use these variables to break up large payloads into smaller chunks, or "pages". We could then choose to display these chunks as distinct pages to the user, or use an infinite loading approach and append each new chunk to the existing list of posts.
+
+#### Separate pages
+
+Here is an example where we display the paginated queries on separate pages:
+
+```jsx
+import { React, useState } from 'react';
+import { useQuery } from 'graphql-hooks';
+
+export default function PostList() {
+  // set a default offset of 0 to load the first page
+  const [skipCount, setSkipCount] = useState(0);
+
+  const { loading, error, data } = useQuery(allPostsQuery, {
+    variables: { skip: skipCount, first: 10 }
+  });
+
+  if (error) return <div>There was an error!</div>;
+  if (loading && !data) return <div>Loading</div>;
+
+  const { allPosts, _allPostsMeta } = data;
+  const areMorePosts = allPosts.length < _allPostsMeta.count;
+
+  return (
+    <section>
+      <ul>
+        {allPosts.map(post => (
+          <li key={post.id}>
+            <a href={post.url}>{post.title}</a>
+          </li>
+        ))}
+      </ul>
+      <button
+        // reduce the offset by 10 to fetch the previous page
+        onClick={() => setSkipCount(skipCount - 10)}
+        disabled={skipCount === 0}
+      >
+        Previous page
+      </button>
+      <button
+        // increase the offset by 10 to fetch the next page
+        onClick={() => setSkipCount(skipCount + 10)}
+        disabled={!areMorePosts}
+      >
+        Next page
+      </button>
+    </section>
+  );
+}
+```
+
+#### Infinite loading
+
+Here is an example where we append each paginated query to the bottom of the current list:
+
+```jsx
+import { React, useState } from 'react';
+import { useQuery } from 'graphql-hooks';
+
+// use options.updateResult to append the new page of posts to our current list of posts
+const updateResult = (prevResult, result) => ({
+  ...result,
+  allPosts: [...prevResult.allPosts, ...result.allPosts]
+});
+
+export default function PostList() {
+  const [skipCount, setSkipCount] = useState(0);
+
+  const { loading, error, data } = useQuery(
+    allPostsQuery,
+    { variables: { skip: skipCount, first: 10 } },
+    updateResult
+  );
+
+  if (error) return <div>There was an error!</div>;
+  if (loading && !data) return <div>Loading</div>;
+
+  const { allPosts, _allPostsMeta } = data;
+  const areMorePosts = allPosts.length < _allPostsMeta.count;
+
+  return (
+    <section>
+      <ul>
+        {allPosts.map(post => (
+          <li key={post.id}>
+            <a href={post.url}>{post.title}</a>
+          </li>
+        ))}
+      </ul>
+      {areMorePosts && (
+        <button
+          // set the offset to the current number of posts to fetch the next page
+          onClick={() => setSkipCount(allPosts.length)}
+        >
+          Show more
+        </button>
+      )}
+    </section>
+  );
+}
+```
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ import { React, useState } from 'react';
 import { useQuery } from 'graphql-hooks';
 
 // use options.updateData to append the new page of posts to our current list of posts
-const updateData = (prevResult, result) => ({
-  ...result,
-  allPosts: [...prevResult.allPosts, ...result.allPosts]
+const updateData = (prevData, data) => ({
+  ...data,
+  allPosts: [...prevData.allPosts, ...data.allPosts]
 });
 
 export default function PostList() {

--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -60,7 +60,7 @@ function useClientRequest(query, initialOpts = {}) {
   });
 
   // arguments to fetchData override the useClientRequest arguments
-  async function fetchData(newOpts, updateResult) {
+  async function fetchData(newOpts) {
     const revisedOpts = {
       ...initialOpts,
       ...newOpts
@@ -90,8 +90,11 @@ function useClientRequest(query, initialOpts = {}) {
     dispatch({ type: actionTypes.LOADING });
     let result = await client.request(revisedOperation, revisedOpts);
 
-    if (result.data && updateResult && typeof updateResult === 'function') {
-      result.data = updateResult(state.data, result.data);
+    if (state.data && result.data && revisedOpts.updateResult) {
+      if (typeof revisedOpts.updateResult !== 'function') {
+        throw new Error('options.updateResult must be a function');
+      }
+      result.data = revisedOpts.updateResult(state.data, result.data);
     }
 
     if (revisedOpts.useCache && client.cache) {

--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -60,7 +60,7 @@ function useClientRequest(query, initialOpts = {}) {
   });
 
   // arguments to fetchData override the useClientRequest arguments
-  async function fetchData(newOpts) {
+  async function fetchData(newOpts, updateResult) {
     const revisedOpts = {
       ...initialOpts,
       ...newOpts
@@ -88,7 +88,11 @@ function useClientRequest(query, initialOpts = {}) {
     }
 
     dispatch({ type: actionTypes.LOADING });
-    const result = await client.request(revisedOperation, revisedOpts);
+    let result = await client.request(revisedOperation, revisedOpts);
+
+    if (result.data && updateResult && typeof updateResult === 'function') {
+      result.data = updateResult(state.data, result.data);
+    }
 
     if (revisedOpts.useCache && client.cache) {
       client.cache.set(revisedCacheKey, result);

--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -90,11 +90,11 @@ function useClientRequest(query, initialOpts = {}) {
     dispatch({ type: actionTypes.LOADING });
     let result = await client.request(revisedOperation, revisedOpts);
 
-    if (state.data && result.data && revisedOpts.updateResult) {
-      if (typeof revisedOpts.updateResult !== 'function') {
-        throw new Error('options.updateResult must be a function');
+    if (state.data && result.data && revisedOpts.updateData) {
+      if (typeof revisedOpts.updateData !== 'function') {
+        throw new Error('options.updateData must be a function');
       }
-      result.data = revisedOpts.updateResult(state.data, result.data);
+      result.data = revisedOpts.updateData(state.data, result.data);
     }
 
     if (revisedOpts.useCache && client.cache) {

--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -31,7 +31,7 @@ module.exports = function useQuery(query, opts = {}) {
     refetch: (options = {}) =>
       queryReq({
         skipCache: true,
-        updateResult: (_, result) => result,
+        updateData: (_, data) => data,
         ...options
       })
   };

--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -7,7 +7,7 @@ const defaultOpts = {
   useCache: true
 };
 
-module.exports = function useQuery(query, opts = {}) {
+module.exports = function useQuery(query, opts = {}, updateResult) {
   const allOpts = { ...defaultOpts, ...opts };
   const client = React.useContext(ClientContext);
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false);
@@ -23,25 +23,20 @@ module.exports = function useQuery(query, opts = {}) {
   }
 
   React.useEffect(() => {
-    queryReq();
+    queryReq(null, updateResult);
   }, [query, JSON.stringify(opts.variables)]);
 
   return {
     ...state,
     refetch: () => queryReq({ skipCache: true }),
-    fetchMore: (fetchMoreOpts, updateResult) => {
-      if (!updateResult) {
-        throw new Error(
-          'useQuery fetchMore: updateResult function is required'
-        );
-      }
+    fetchMore: (fetchMoreOpts, updateResultOverride) => {
       queryReq(
         {
           ...allOpts,
           ...fetchMoreOpts,
           variables: { ...opts.variables, ...fetchMoreOpts.variables }
         },
-        updateResult
+        updateResultOverride || updateResult
       );
     }
   };

--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -28,10 +28,11 @@ module.exports = function useQuery(query, opts = {}) {
 
   return {
     ...state,
-    refetch: () => queryReq({ skipCache: true }),
-    fetchMore: ({ variables, ...rest } = {}) =>
-      // merge variables so they don't all have to be passed back in,
-      // just the ones that are changing
-      queryReq({ ...rest, variables: { ...allOpts.variables, ...variables } })
+    refetch: (options = {}) =>
+      queryReq({
+        skipCache: true,
+        updateResult: (_, result) => result,
+        ...options
+      })
   };
 };

--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -29,7 +29,7 @@ module.exports = function useQuery(query, opts = {}) {
   return {
     ...state,
     refetch: () => queryReq({ skipCache: true }),
-    fetchMore: ({ variables = {}, ...rest } = {}) =>
+    fetchMore: ({ variables, ...rest } = {}) =>
       // merge variables so they don't all have to be passed back in,
       // just the ones that are changing
       queryReq({ ...rest, variables: { ...allOpts.variables, ...variables } })

--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -7,7 +7,7 @@ const defaultOpts = {
   useCache: true
 };
 
-module.exports = function useQuery(query, opts = {}, updateResult) {
+module.exports = function useQuery(query, opts = {}) {
   const allOpts = { ...defaultOpts, ...opts };
   const client = React.useContext(ClientContext);
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false);
@@ -23,21 +23,15 @@ module.exports = function useQuery(query, opts = {}, updateResult) {
   }
 
   React.useEffect(() => {
-    queryReq(null, updateResult);
+    queryReq();
   }, [query, JSON.stringify(opts.variables)]);
 
   return {
     ...state,
     refetch: () => queryReq({ skipCache: true }),
-    fetchMore: (fetchMoreOpts, updateResultOverride) => {
-      queryReq(
-        {
-          ...allOpts,
-          ...fetchMoreOpts,
-          variables: { ...opts.variables, ...fetchMoreOpts.variables }
-        },
-        updateResultOverride || updateResult
-      );
-    }
+    fetchMore: ({ variables = {}, ...rest } = {}) =>
+      // merge variables so they don't all have to be passed back in,
+      // just the ones that are changing
+      queryReq({ ...rest, variables: { ...allOpts.variables, ...variables } })
   };
 };

--- a/src/useQuery.js
+++ b/src/useQuery.js
@@ -31,6 +31,9 @@ module.exports = function useQuery(query, opts = {}) {
     refetch: (options = {}) =>
       queryReq({
         skipCache: true,
+        // don't call the updateData that has been passed into useQuery here
+        // reset to the default behaviour of returning the raw query result
+        // this can be overridden in refetch options
         updateData: (_, data) => data,
         ...options
       })

--- a/test/unit/useClientRequest.test.js
+++ b/test/unit/useClientRequest.test.js
@@ -219,12 +219,12 @@ describe('useClientRequest', () => {
     describe('options.updateRequest', () => {
       it('is called with old & new data if the data has changed & the result is returned', async () => {
         let fetchData, state;
-        const updateResultMock = jest.fn().mockReturnValue('merged data');
+        const updateDataMock = jest.fn().mockReturnValue('merged data');
         testHook(
           () =>
             ([fetchData, state] = useClientRequest(TEST_QUERY, {
               variables: { limit: 10 },
-              updateResult: updateResultMock
+              updateData: updateDataMock
             })),
           { wrapper: Wrapper }
         );
@@ -235,7 +235,7 @@ describe('useClientRequest', () => {
         mockClient.request.mockResolvedValueOnce({ data: 'new data' });
         await fetchData({ variables: { limit: 20 } });
 
-        expect(updateResultMock).toHaveBeenCalledWith('data', 'new data');
+        expect(updateDataMock).toHaveBeenCalledWith('data', 'new data');
         expect(state).toEqual({
           cacheHit: false,
           data: 'merged data',
@@ -245,29 +245,29 @@ describe('useClientRequest', () => {
 
       it('is not called if there is no old data', async () => {
         let fetchData;
-        const updateResultMock = jest.fn();
+        const updateDataMock = jest.fn();
         testHook(
           () =>
             ([fetchData] = useClientRequest(TEST_QUERY, {
               variables: { limit: 10 },
-              updateResult: updateResultMock
+              updateData: updateDataMock
             })),
           { wrapper: Wrapper }
         );
 
         await fetchData();
 
-        expect(updateResultMock).not.toHaveBeenCalled();
+        expect(updateDataMock).not.toHaveBeenCalled();
       });
 
       it('is not called if there is no new data', async () => {
         let fetchData;
-        const updateResultMock = jest.fn();
+        const updateDataMock = jest.fn();
         testHook(
           () =>
             ([fetchData] = useClientRequest(TEST_QUERY, {
               variables: { limit: 10 },
-              updateResult: updateResultMock
+              updateData: updateDataMock
             })),
           { wrapper: Wrapper }
         );
@@ -277,16 +277,16 @@ describe('useClientRequest', () => {
         mockClient.request.mockReturnValueOnce({ errors: ['on no!'] });
         await fetchData({ variables: { limit: 20 } });
 
-        expect(updateResultMock).not.toHaveBeenCalled();
+        expect(updateDataMock).not.toHaveBeenCalled();
       });
 
-      it('throws if updateResult is not a function', async () => {
+      it('throws if updateData is not a function', async () => {
         let fetchData;
         testHook(
           () =>
             ([fetchData] = useClientRequest(TEST_QUERY, {
               variables: { limit: 10 },
-              updateResult: 'do I look like a function to you?'
+              updateData: 'do I look like a function to you?'
             })),
           { wrapper: Wrapper }
         );
@@ -295,7 +295,7 @@ describe('useClientRequest', () => {
         await fetchData();
 
         expect(fetchData({ variables: { limit: 20 } })).rejects.toThrow(
-          'options.updateResult must be a function'
+          'options.updateData must be a function'
         );
       });
     });

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -69,7 +69,7 @@ describe('useQuery', () => {
     refetch();
     expect(mockQueryReq).toHaveBeenCalledWith({
       skipCache: true,
-      updateResult: expect.any(Function)
+      updateData: expect.any(Function)
     });
   });
 
@@ -84,21 +84,21 @@ describe('useQuery', () => {
         wrapper: Wrapper
       }
     );
-    const updateResult = () => {};
+    const updateData = () => {};
     refetch({
       extra: 'option',
       variables: { skip: 10, first: 10, extra: 'variable' },
-      updateResult
+      updateData
     });
     expect(mockQueryReq).toHaveBeenCalledWith({
       skipCache: true,
       extra: 'option',
       variables: { skip: 10, first: 10, extra: 'variable' },
-      updateResult
+      updateData
     });
   });
 
-  it('gets updateResult to replace the result by default', () => {
+  it('gets updateData to replace the result by default', () => {
     let refetch;
     testHook(
       () =>
@@ -109,11 +109,11 @@ describe('useQuery', () => {
         wrapper: Wrapper
       }
     );
-    mockQueryReq.mockImplementationOnce(({ updateResult }) => {
-      return updateResult('previousResult', 'result');
+    mockQueryReq.mockImplementationOnce(({ updateData }) => {
+      return updateData('previousData', 'data');
     });
     refetch();
-    expect(mockQueryReq).toHaveReturnedWith('result');
+    expect(mockQueryReq).toHaveReturnedWith('data');
   });
 
   it('sends the query on mount if no data & no error', () => {

--- a/test/unit/useQuery.test.js
+++ b/test/unit/useQuery.test.js
@@ -53,13 +53,14 @@ describe('useQuery', () => {
     });
   });
 
-  it('returns initial state from useClientRequest & refetch', () => {
+  it('returns initial state from useClientRequest, refetch & fetchMore', () => {
     let state;
     testHook(() => (state = useQuery(TEST_QUERY)), { wrapper: Wrapper });
     expect(state).toEqual({
       loading: true,
       cacheHit: false,
-      refetch: expect.any(Function)
+      refetch: expect.any(Function),
+      fetchMore: expect.any(Function)
     });
   });
 
@@ -68,6 +69,41 @@ describe('useQuery', () => {
     testHook(() => ({ refetch } = useQuery(TEST_QUERY)), { wrapper: Wrapper });
     refetch();
     expect(mockQueryReq).toHaveBeenCalledWith({ skipCache: true });
+  });
+
+  it('sends a query with original options when fetchMore is called', () => {
+    let fetchMore;
+    testHook(
+      () =>
+        ({ fetchMore } = useQuery(TEST_QUERY, {
+          variables: { skip: 0, first: 10 }
+        })),
+      {
+        wrapper: Wrapper
+      }
+    );
+    fetchMore();
+    expect(mockQueryReq).toHaveBeenCalledWith({
+      variables: { skip: 0, first: 10 }
+    });
+  });
+
+  it('passes options & merges variables when fetchMore is called', () => {
+    let fetchMore;
+    testHook(
+      () =>
+        ({ fetchMore } = useQuery(TEST_QUERY, {
+          variables: { skip: 0, first: 10 }
+        })),
+      {
+        wrapper: Wrapper
+      }
+    );
+    fetchMore({ extra: 'option', variables: { skip: 10, extra: 'variable' } });
+    expect(mockQueryReq).toHaveBeenCalledWith({
+      extra: 'option',
+      variables: { skip: 10, first: 10, extra: 'variable' }
+    });
   });
 
   it('sends the query on mount if no data & no error', () => {


### PR DESCRIPTION
Closes: #41, closes #42, and closes #29 

~Provides a `fetchMore` function that will send the same query with the provided options merged into the original options, meaning the consumer doesn't have to manually maintain the state.~ Removed this as the same can be achieved with `refetch` now that it accepts `options`.

`useQuery` accepts an `updateData` function as part of the `options` object that enables control of how the previous & new results are merged, this function can be overridden if necessary when calling `refetch` as well.

### TODO
- [x] Agree on implementation
- [x] Test coverage
- [x] Update documentation

### Example usage

```jsx
// use options.updateResult to append the new page of posts to our current list of posts
const updateData = (prevData, prevData) => ({
  ...data,
  allPosts: [...prevData.allPosts, ...data.allPosts]
});

export default function PostList() {
  // set a default offset of 0 to load the first page
  const [skipCount, setSkipCount] = useState(0);

  const { loading, error, data } = useQuery(
    allPostsQuery,
    { variables: { skip: skipCount, first: 10 } },
    updateData
  );

  if (error) return <div>There was an error!</div>;
  if (loading && !data) return <div>Loading</div>;

  const { allPosts, _allPostsMeta } = data;
  const areMorePosts = allPosts.length < _allPostsMeta.count;

  return (
    <section>
      <ul>
        {allPosts.map(post => (
          <li key={post.id}>
            <a href={post.url}>{post.title}</a>
          </li>
        ))}
      </ul>
      {areMorePosts && (
        <button
          // set the offset to the current number of posts to fetch the next page
          onClick={() => setSkipCount(allPosts.length)}
        >
          Show more
        </button>
      )}
    </section>
  );
}
```