### PR TITLE
Add bug & feature labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,6 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: Bugs or any unexpected issues.
+labels: bug
 ---
 
 ### Environment

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,6 +1,7 @@
 ---
 name: 💡 Feature Request
 about: I have a suggestion for a new feature!
+labels: feature
 ---
 
 ### Description


### PR DESCRIPTION
### What does this PR do?

Automatically adds bug & feature labels when raising an issue via the Bug Report or Feature Request issue templates

See https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
