### PR TITLE
feat: remove all-contributors cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ Make sure to get a `:thumbsup:`, `+1` or `LGTM` from another collaborator before
 
 ## Updating Contributors list in README.md
 
-You can add yourself or another contributor by either:
+You can add yourself or another contributor by commenting on an issue or pull request:
 
-- Comment on an issue or pull request `@all-contributors please add <username> for <contributions>`
-- `npm run contributors:add`
+```
+@all-contributors please add <username> for <contributions>
+```
 
 For more information on `@all-contributors` see it's [usage docs](https://allcontributors.org/docs/en/bot/usage)
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "prettier": "pretty-quick",
-    "contributors:add": "all-contributors add",
-    "contributors:generate": "all-contributors generate"
+    "prettier": "pretty-quick"
   },
   "keywords": [
     "graphql",
@@ -29,7 +27,6 @@
   "devDependencies": {
     "@babel/preset-env": "7.3.4",
     "@babel/preset-react": "7.0.0",
-    "all-contributors-cli": "6.1.2",
     "babel-jest": "24.1.0",
     "husky": "1.3.1",
     "jest": "24.1.0",


### PR DESCRIPTION
### What does this PR do?
- Removes CLI tool for `all-contributors`
- Using the CLI tool as opposed to bot usage yielded inconsistencies. The CLI generated markup whilst the bot generated markdown.
<!-- A brief description of what this pull request is for, please provide any background -->

<!-- Link to any related issues here -->

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
