### PR TITLE
fix: Preserve state if updateData is passed to useClientRequest.

### DIFF
--- a/src/useClientRequest.js
+++ b/src/useClientRequest.js
@@ -72,6 +72,7 @@ function useClientRequest(query, initialOpts = {}) {
   // in subsequent renders the operation could have changed
   // if so the state would be invalid, this effect ensures we reset it back
   React.useEffect(() => {
+    if (initialOpts.updateData) return; // if using updateData we can assume that the consumer cares about the previous data
     dispatch({ type: actionTypes.RESET_STATE, initialState });
   }, [JSON.stringify(cacheKey)]);
 


### PR DESCRIPTION
### What does this PR do?
After updating the next.js example with the latest release we noticed that all our data would disappear when fetching more results. The way we recommend to do that is by updating the variables passed into `useQuery` and supplying an `updateData` method, which is responsible for merging the previous and new results. 

We previously merged a fix (#61) that resets state if variables or query changes in `useClientRequest`. The fix in this is to only reset the state if `updateData` is not set. This means that `state.data` is always populated after the initial request in this scenario.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
