### PR TITLE
Stop lerna generating package lock files in packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,9 @@
 {
   "packages": ["packages/*"],
-  "version": "independent"
+  "version": "independent",
+  "command": {
+    "bootstrap": {
+      "npmClientArgs": ["--no-package-lock"]
+    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Prevents `package-lock.json` files being generated in the `packages/` directory.

### Related issues

#65 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
