### PR TITLE
chore: don't use lerna github releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ For more information on `@all-contributors` see it's [usage docs](https://allcon
 When merging a pull request to `master`, the squashed commit message should follow the [Conventional Commits](https://www.conventionalcommits.org) specification. This enables us to automatically generate CHANGELOGs & determine a semantic version bump.
 
 - `npm test`
-- `NPM_CONFIG_OTP=<your-otp> GH_TOKEN=<your-github-token> npm run release`
+- `NPM_CONFIG_OTP=<your-otp> npm run release`
 
 Follow the prompts from [`lerna publish`](https://lernajs.io/#command-publish)
 

--- a/lerna.json
+++ b/lerna.json
@@ -10,8 +10,7 @@
       "message": "chore(release): :rocket:"
     },
     "version": {
-      "conventionalCommits": true,
-      "githubRelease": true
+      "conventionalCommits": true
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of what this pull request is for, please provide any background -->

Removes Lerna's github release config as it doesn't seem to work well in local testing. Maybe something we can come back to.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
