### PR TITLE
feat: cjs, es & umd bundles for graphql-hooks-memcache

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,0 +1,116 @@
+import path from 'path'
+import nodeResolve from 'rollup-plugin-node-resolve'
+import babel from 'rollup-plugin-babel'
+import replace from 'rollup-plugin-replace'
+import commonjs from 'rollup-plugin-commonjs'
+import { terser } from 'rollup-plugin-terser'
+import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
+
+// get the package.json for the current package
+const packageDir = path.join(__filename, '..')
+const pkg = require(`${packageDir}/package.json`)
+const external = [...Object.keys(pkg.peerDependencies || {})]
+
+// name will be used as the global name exposed in the UMD bundles
+const generateRollupConfig = name => [
+  // CommonJS
+  {
+    input: 'src/index.js',
+    output: { file: `lib/${pkg.name}.js`, format: 'cjs', indent: false },
+    external,
+    plugins: [babel(), sizeSnapshot()]
+  },
+
+  // ES
+  {
+    input: 'src/index.js',
+    output: { file: `es/${pkg.name}.js`, format: 'es', indent: false },
+    external,
+    plugins: [babel(), sizeSnapshot()]
+  },
+
+  // ES for Browsers
+  {
+    input: 'src/index.js',
+    output: { file: `es/${pkg.name}.mjs`, format: 'es', indent: false },
+    external,
+    plugins: [
+      commonjs(),
+      nodeResolve({
+        jsnext: true
+      }),
+      replace({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
+      terser({
+        compress: {
+          pure_getters: true,
+          unsafe: true,
+          unsafe_comps: true,
+          warnings: false
+        }
+      }),
+      sizeSnapshot()
+    ]
+  },
+
+  // UMD Development
+  {
+    input: 'src/index.js',
+    output: {
+      file: `dist/${pkg.name}.js`,
+      format: 'umd',
+      name,
+      indent: false
+    },
+    external,
+    plugins: [
+      commonjs(),
+      nodeResolve({
+        jsnext: true
+      }),
+      babel({
+        exclude: 'node_modules/**'
+      }),
+      replace({
+        'process.env.NODE_ENV': JSON.stringify('development')
+      }),
+      sizeSnapshot()
+    ]
+  },
+
+  // UMD Production
+  {
+    input: 'src/index.js',
+    output: {
+      file: `dist/${pkg.name}.min.js`,
+      format: 'umd',
+      name,
+      indent: false
+    },
+    external,
+    plugins: [
+      commonjs(),
+      nodeResolve({
+        jsnext: true
+      }),
+      babel({
+        exclude: 'node_modules/**'
+      }),
+      replace({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
+      terser({
+        compress: {
+          pure_getters: true,
+          unsafe: true,
+          unsafe_comps: true,
+          warnings: false
+        }
+      }),
+      sizeSnapshot()
+    ]
+  }
+]
+
+export default generateRollupConfig

--- a/package.json
+++ b/package.json
@@ -16,16 +16,23 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "24.1.0",
     "coveralls": "3.0.3",
+    "eslint": "5.15.1",
     "eslint-config-prettier": "4.1.0",
     "eslint-plugin-prettier": "3.0.1",
-    "eslint-plugin-react-hooks": "1.4.0",
     "eslint-plugin-react": "7.12.4",
-    "eslint": "5.15.1",
+    "eslint-plugin-react-hooks": "1.4.0",
     "husky": "1.3.1",
     "jest": "24.1.0",
     "lerna": "3.13.1",
     "lint-staged": "8.1.5",
-    "prettier": "1.16.4"
+    "prettier": "1.16.4",
+    "rollup": "1.5.0",
+    "rollup-plugin-babel": "4.3.2",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-resolve": "4.0.1",
+    "rollup-plugin-replace": "2.1.0",
+    "rollup-plugin-size-snapshot": "0.8.0",
+    "rollup-plugin-terser": "4.0.4"
   },
   "lint-staged": {
     "./packages/*/{src,test}/**/*.js": [

--- a/packages/graphql-hooks-memcache/.size-snapshot.json
+++ b/packages/graphql-hooks-memcache/.size-snapshot.json
@@ -1,0 +1,45 @@
+{
+  "lib/graphql-hooks-memcache.js": {
+    "bundled": 936,
+    "minified": 621,
+    "gzipped": 369
+  },
+  "es/graphql-hooks-memcache.js": {
+    "bundled": 763,
+    "minified": 490,
+    "gzipped": 311,
+    "treeshaked": {
+      "rollup": {
+        "code": 45,
+        "import_statements": 45
+      },
+      "webpack": {
+        "code": 1062
+      }
+    }
+  },
+  "es/graphql-hooks-memcache.mjs": {
+    "bundled": 2080,
+    "minified": 2076,
+    "gzipped": 886,
+    "treeshaked": {
+      "rollup": {
+        "code": 1471,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 2521
+      }
+    }
+  },
+  "dist/graphql-hooks-memcache.js": {
+    "bundled": 4451,
+    "minified": 2281,
+    "gzipped": 973
+  },
+  "dist/graphql-hooks-memcache.min.js": {
+    "bundled": 2277,
+    "minified": 2263,
+    "gzipped": 969
+  }
+}

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist",
     "es",
-    "lib"
+    "lib",
+    "src"
   ],
   "keywords": [
     "graphql",

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -2,11 +2,19 @@
   "name": "graphql-hooks-memcache",
   "version": "1.0.8",
   "description": "In memory cache for graphql-hooks",
-  "main": "index.js",
+  "main": "lib/graphql-hooks-memcache.js",
+  "module": "es/graphql-hooks-memcache.js",
+  "unpkg": "dist/graphql-hooks-memcache.min.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "build": "../../node_modules/.bin/rollup -c",
+    "prepublishOnly": "npm run build && cp ../../LICENSE ."
   },
+  "files": [
+    "dist",
+    "es",
+    "lib"
+  ],
   "keywords": [
     "graphql",
     "hooks",

--- a/packages/graphql-hooks-memcache/rollup.config.js
+++ b/packages/graphql-hooks-memcache/rollup.config.js
@@ -1,3 +1,3 @@
 import generateRollupConfig from '../../config/rollup.config'
 
-export default generateRollupConfig('GraphQLHooks')
+export default generateRollupConfig('GraphQLHooksMemcache')

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -1,11 +1,11 @@
-const LRU = require('tiny-lru')
-const fnv1a = require('@sindresorhus/fnv1a')
+import LRU from 'tiny-lru'
+import fnv1a from '@sindresorhus/fnv1a'
 
 function generateKey(keyObj) {
   return fnv1a(JSON.stringify(keyObj)).toString(36)
 }
 
-module.exports = function memCache({ size = 100, ttl = 0, initialState } = {}) {
+export default function memCache({ size = 100, ttl = 0, initialState } = {}) {
   const lru = LRU(size, ttl)
 
   if (initialState) {

--- a/packages/graphql-hooks/.size-snapshot.json
+++ b/packages/graphql-hooks/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "lib/graphql-hooks.js": {
-    "bundled": 11191,
-    "minified": 5591,
-    "gzipped": 1912
+    "bundled": 11781,
+    "minified": 5768,
+    "gzipped": 1968
   },
   "es/graphql-hooks.js": {
-    "bundled": 10846,
-    "minified": 5299,
-    "gzipped": 1837,
+    "bundled": 11436,
+    "minified": 5476,
+    "gzipped": 1896,
     "treeshaked": {
       "rollup": {
         "code": 67,
@@ -19,9 +19,9 @@
     }
   },
   "es/graphql-hooks.mjs": {
-    "bundled": 3939,
-    "minified": 3939,
-    "gzipped": 1515,
+    "bundled": 4091,
+    "minified": 4091,
+    "gzipped": 1566,
     "treeshaked": {
       "rollup": {
         "code": 67,
@@ -33,13 +33,13 @@
     }
   },
   "dist/graphql-hooks.js": {
-    "bundled": 11438,
-    "minified": 5099,
-    "gzipped": 1915
+    "bundled": 12028,
+    "minified": 5268,
+    "gzipped": 1975
   },
   "dist/graphql-hooks.min.js": {
-    "bundled": 5055,
-    "minified": 5055,
-    "gzipped": 1891
+    "bundled": 5224,
+    "minified": 5224,
+    "gzipped": 1948
   }
 }

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist",
     "es",
-    "lib"
+    "lib",
+    "src"
   ],
   "keywords": [
     "graphql",

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -6,7 +6,7 @@
   "module": "es/graphql-hooks.js",
   "unpkg": "dist/graphql-hooks.min.js",
   "scripts": {
-    "build": "rollup -c",
+    "build": "../../node_modules/.bin/rollup -c",
     "prepublishOnly": "npm run build && cp ../../README.md . && cp ../../LICENSE ."
   },
   "files": [
@@ -34,12 +34,7 @@
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "react-hooks-testing-library": "0.3.4",
-    "react-testing-library": "6.0.0",
-    "rollup": "1.5.0",
-    "rollup-plugin-babel": "4.3.2",
-    "rollup-plugin-node-resolve": "4.0.1",
-    "rollup-plugin-size-snapshot": "0.8.0",
-    "rollup-plugin-terser": "4.0.4"
+    "react-testing-library": "6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What does this PR do?

- Creates a shared rollup config at the root
- Moves rollup & related dependencies to root
- Adds a rollup config, build & prepublish steps for `graphql-hooks-memcache`

### Related issues

Closes #95 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
