### PR TITLE
test: Add test for getInitialState in graphql-hooks-ssr

### DIFF
--- a/packages/graphql-hooks-ssr/index.test.js
+++ b/packages/graphql-hooks-ssr/index.test.js
@@ -1,0 +1,30 @@
+import { getInitialState } from './index'
+
+describe('getInitialState', () => {
+  it('runs all promises and returns state from cache', async () => {
+    const MockApp = () => 'hello world'
+
+    let resolvedPromises = 0
+    const promiseCounter = jest.fn().mockImplementation(() => {
+      resolvedPromises++
+      return Promise.resolve()
+    })
+
+    const ssrPromises = [promiseCounter(), promiseCounter()]
+
+    const mockClient = {
+      ssrPromises,
+      cache: {
+        getInitialState: jest.fn().mockReturnValue({ foo: 'bar' })
+      }
+    }
+
+    const result = await getInitialState({
+      App: MockApp,
+      client: mockClient
+    })
+
+    expect(result).toEqual({ foo: 'bar' })
+    expect(resolvedPromises).toBe(2)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds a small test for getInitialState in the graphql-hooks-ssr package.

### Related issues

closes #94 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
