### PR TITLE
fix: throw an error if client.cache isn't provided in ssrMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const client = new GraphQLClient(config)
 
 - `url` (**Required**): The url to your GraphQL server
 - `ssrMode`: Boolean - set to `true` when using on the server for server-side rendering; defaults to `false`
-- `cache`: Object with the following methods:
+- `cache` (**Required** if `ssrMode` is `true`, otherwise optional): Object with the following methods:
   - `cache.get(key)`
   - `cache.set(key, data)`
   - `cache.delete(key)`

--- a/packages/graphql-hooks-ssr/README.md
+++ b/packages/graphql-hooks-ssr/README.md
@@ -26,7 +26,7 @@ app.get('/', async (req, reply) => {
   // Step 1: Create the client inside the request handler
   const client = new GraphQLClient({
     url: 'https://domain.com/graphql',
-    cache: memCache(),
+    cache: memCache() // NOTE: a cache is required for SSR,
     fetch
   })
 

--- a/packages/graphql-hooks-ssr/index.js
+++ b/packages/graphql-hooks-ssr/index.js
@@ -2,6 +2,13 @@ const ReactDOMServer = require('react-dom/server')
 
 async function getInitialState(opts) {
   const { App, client, render = ReactDOMServer.renderToStaticMarkup } = opts
+
+  if (!client.cache) {
+    throw new Error(
+      'A cache implementation must be provided for SSR, please pass one to `GraphQLClient` via `options`.'
+    )
+  }
+
   // ensure ssrMode is set:
   client.ssrMode = true
   render(App)

--- a/packages/graphql-hooks-ssr/index.test.js
+++ b/packages/graphql-hooks-ssr/index.test.js
@@ -27,4 +27,23 @@ describe('getInitialState', () => {
     expect(result).toEqual({ foo: 'bar' })
     expect(resolvedPromises).toBe(2)
   })
+
+  it("throws if a cache hasn't been provided", async () => {
+    const MockApp = () => 'hello world'
+
+    const mockClient = {
+      ssrPromises: []
+    }
+
+    expect(
+      getInitialState({
+        App: MockApp,
+        client: mockClient
+      })
+    ).rejects.toEqual(
+      new Error(
+        'A cache implementation must be provided for SSR, please pass one to `GraphQLClient` via `options`.'
+      )
+    )
+  })
 })

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -15,6 +15,10 @@ class GraphQLClient {
       )
     }
 
+    if (config.ssrMode && !config.cache) {
+      throw new Error('GraphQLClient: config.cache is required when in ssrMode')
+    }
+
     this.cache = config.cache
     this.headers = config.headers || {}
     this.ssrMode = config.ssrMode

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -37,6 +37,15 @@ describe('GraphQLClient', () => {
       global.fetch = oldFetch
     })
 
+    it('throws if config.ssrMode is true and no config.cache is provided', () => {
+      expect(() => {
+        new GraphQLClient({
+          ...validConfig,
+          ssrMode: true
+        })
+      }).toThrow('GraphQLClient: config.cache is required when in ssrMode')
+    })
+
     it('assigns config.cache to an instance property', () => {
       const cache = { get: 'get', set: 'set' }
       const client = new GraphQLClient({ ...validConfig, cache })
@@ -49,8 +58,12 @@ describe('GraphQLClient', () => {
       expect(client.headers).toBe(headers)
     })
 
-    it('assigns config.ssrMode to an instance property', () => {
-      const client = new GraphQLClient({ ...validConfig, ssrMode: true })
+    it('assigns config.ssrMode to an instance property if config.cache is provided', () => {
+      const client = new GraphQLClient({
+        ...validConfig,
+        ssrMode: true,
+        cache: { get: 'get', set: 'set' }
+      })
       expect(client.ssrMode).toBe(true)
     })
 


### PR DESCRIPTION
### What does this PR do?

- Makes `graphql-hooks-ssr` `getInitialState` throw if no cache is present in the client
- Makes `GraphQLClient` throw if `ssrMode` is true & no cache is provided
- Updates docs to reflect that `client.cache` is required in SSR mode
- Adds regression tests

### Related issues

Fixes #116 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
