### PR TITLE
test: Acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,21 @@ jobs:
           path: reports/junit
 
       - run: npm run coveralls
+  acceptance-tests:
+    working_directory: ~/graphql-hooks
+    docker:
+      - image: circleci/node:10.15
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+
+      - run: npm install
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+
+      - run: npm run test:acceptance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
       - run: npm run coveralls
   acceptance-tests:
     working_directory: ~/graphql-hooks
+    environment:
+      BROWSERSTACK_PARALLEL_RUNS: '5'
+      BROWSERSTACK_USE_AUTOMATE: '1'
+      BROWSERSTACK_PROJECT_NAME: 'graphql-hooks'
     docker:
       - image: circleci/node:10.15
     steps:
@@ -51,4 +55,7 @@ jobs:
           paths:
             - node_modules
 
-      - run: npm run test:acceptance
+      - run: npm run test:acceptance:ci
+
+      - store_test_results:
+          path: /tmp/acceptance-test-results

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,9 @@ module.exports = {
   ],
   globals: {
     Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly'
+    SharedArrayBuffer: 'readonly',
+    fixture: true,
+    test: true
   },
   parserOptions: {
     ecmaFeatures: {

--- a/.netlify/functions/deploy-succeeded.js
+++ b/.netlify/functions/deploy-succeeded.js
@@ -1,0 +1,49 @@
+const https = require('https')
+
+exports.handler = function(event, context, callback) {
+  const e = JSON.parse(event.body)
+
+  const options = {
+    hostname: 'circleci.com',
+    port: 443,
+    path: `/api/v1.1/project/github/nearform/graphql-hooks/tree/${
+      e.payload.branch
+    }`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    auth: process.env.CIRCLECI_PROJECT_TOKEN
+  }
+
+  const postData = JSON.stringify({
+    build_parameters: {
+      CIRCLE_JOB: 'acceptance-tests',
+      ACCEPTANCE_URL: e.payload.deploy_ssl_url
+    }
+  })
+
+  const req = https.request(options, res => {
+    console.log(`STATUS: ${res.statusCode}`)
+    console.log(`HEADERS: ${JSON.stringify(res.headers)}`)
+    res.setEncoding('utf8')
+    res.on('data', chunk => {
+      console.log(`BODY: ${chunk}`)
+    })
+    res.on('end', () => {
+      console.log('No more data in response.')
+      callback(null, {
+        statusCode: 200,
+        body: 'Success'
+      })
+    })
+  })
+
+  req.on('error', e => {
+    console.error(`problem with request: ${e.message}`)
+  })
+
+  // write data to request body
+  req.write(postData)
+  req.end()
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,12 @@ npm run test:coverage
 **Important**
 We don't use async/await in this library due to transpilation costs. Instead we use Promises and inform the user that they should provide a suitable environment.
 
+### Acceptance tests
+
+We use [testcafe](https://github.com/DevExpress/testcafe) to run acceptance tests against our [create-react-app example](examples/create-react-app) application. This is to ensure that the bundled versions of the code work as they should in an application.
+You can run these locally on Chrome by running `npm run test:acceptance`. You should make sure that the packages have been built and the create-react-app example is running on port 3000 locally.
+When you open a pull request CircleCI will run the tests using [Browserstack](https://browserstack.com) on Chrome, Firefox, Safari and IE 11.
+
 ## For Collaborators
 
 Make sure to get a `:thumbsup:`, `+1` or `LGTM` from another collaborator before merging a PR. If you aren't sure if a release should happen, open an issue.

--- a/README.md
+++ b/README.md
@@ -655,3 +655,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+[![BrowserStack](https://p14.zdusercontent.com/attachment/1015988/mg687dwxHqXtriITEf8kxZV3W?token=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..tPLabhhdTeWxyc3TTt-RCg.bmk4nO95zIaYIcNaaDEVtxph9ap6d9X__07O0wPpvgsx5RBYvue1gMxCGhnYcgtQA51YjC5BFCxev9bBGZ0f6wHGr83j_nBID68oZCdgurHQhuZjsBZTotXtVdGDJoGg8KHMvl2qK9_FFlxohxGkPatEyccPXfLxZGGrGhvGnZVs6sFcy5bSevRHwe84yH3y0-PhbwE9HPAqzYsJyjBsSnez3gllgrIqX_7UucPPyAxtESSOaevl3zs6n5EfJ6teaJ3_KhWTmux9Nlk5csiWwvcRcCXp7p14Xln9tBYR64k.-1SqygSW1Ke0iJ-t3ED3SQ)](http://browserstack.com/)
+
+We use BrowserStack to support as many browsers and devices as possible

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -7,6 +7,7 @@
     "graphql-hooks-memcache": "^1.1.1",
     "prop-types": "15.7.2",
     "react": "16.8.4",
+    "react-app-polyfill": "0.2.2",
     "react-dom": "16.8.4",
     "react-scripts": "2.1.8"
   },

--- a/examples/create-react-app/src/index.js
+++ b/examples/create-react-app/src/index.js
@@ -1,3 +1,4 @@
+import 'react-app-polyfill/ie11'
 import React from 'react'
 import ReactDOM from 'react-dom'
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:acceptance": "echo $ACCEPTANCE_URL",
+    "test:acceptance": "testcafe chrome test/acceptance/",
+    "test:acceptance:ci": "testcafe browserstack:chrome,browserstack:firefox,browserstack:ie,browserstack:safari test/acceptance/ -r xunit:/tmp/acceptance-test-results/res.xml",
     "postinstall": "lerna bootstrap --no-ci",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "eslint": "eslint '**/*.js'",
@@ -33,7 +34,10 @@
     "rollup-plugin-node-resolve": "4.0.1",
     "rollup-plugin-replace": "2.1.0",
     "rollup-plugin-size-snapshot": "0.8.0",
-    "rollup-plugin-terser": "4.0.4"
+    "rollup-plugin-terser": "4.0.4",
+    "testcafe": "1.1.0",
+    "testcafe-browser-provider-browserstack": "1.8.0",
+    "testcafe-reporter-xunit": "2.1.0"
   },
   "lint-staged": {
     "**/*.js": [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "test:acceptance": "echo $ACCEPTANCE_URL",
     "postinstall": "lerna bootstrap --no-ci",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "eslint": "eslint '**/*.js'",

--- a/test/acceptance/basic.acceptance.test.js
+++ b/test/acceptance/basic.acceptance.test.js
@@ -1,0 +1,9 @@
+import { Selector } from 'testcafe'
+import globals from './globals'
+
+fixture('Example app').page(globals.url)
+
+test('The example renders a list of posts', async t => {
+  const listItems = Selector('#root ul li')
+  await t.expect(listItems.count).gt(1)
+})

--- a/test/acceptance/globals.js
+++ b/test/acceptance/globals.js
@@ -1,0 +1,5 @@
+const globals = {
+  url: process.env.ACCEPTANCE_URL || 'http://localhost:3000'
+}
+
+export default globals


### PR DESCRIPTION
### What does this PR do?

Adds a simple acceptance test that ensures the create-react-app example renders a list of posts.

The majority of this PR is setting up the CI. The process is as follows:
- PR is opened
- CircleCI runs normal "test" build
- Netlify deploys preview of create-react-app example.
- Netlify sends a request on `deploy-succeeded` to CircleCI telling it to run the job `acceptance-tests` on correct branch, along with a `ACCEPTANCE_URL` parameter that points to the Netlify preview.
- CircleCI runs `npm run test:acceptance:ci`, which uses testcafe and browserstack.

This process makes use Netlify functions, which handily you can trigger from certain Netlify events. We make use of the `deploy-succeeded` event by naming our function file `deploy-succeeded.js`, easy. 

### Related issues

closes #119 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
