### PR TITLE
Fix default loading stage for useManualQuery

### DIFF
--- a/packages/graphql-hooks/src/index.js
+++ b/packages/graphql-hooks/src/index.js
@@ -4,7 +4,7 @@ import useClientRequest from './useClientRequest'
 import useQuery from './useQuery'
 
 const useManualQuery = (query, options) =>
-  useClientRequest(query, { useCache: true, ...options })
+  useClientRequest(query, { useCache: true, isManual: true, ...options })
 
 const useMutation = (query, options) =>
   useClientRequest(query, { isMutation: true, ...options })

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -60,12 +60,13 @@ function useClientRequest(query, initialOpts = {}) {
   }
 
   const cacheKey = client.getCacheKey(operation, initialOpts)
+  const isDeferred = initialOpts.isMutation || initialOpts.isManual
   const initialCacheHit =
     initialOpts.skipCache || !client.cache ? null : client.cache.get(cacheKey)
   const initialState = {
     ...initialCacheHit,
     cacheHit: !!initialCacheHit,
-    loading: initialOpts.isMutation ? false : !initialCacheHit
+    loading: isDeferred ? false : !initialCacheHit
   }
   const [state, dispatch] = React.useReducer(reducer, initialState)
 

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -159,6 +159,21 @@ describe('useClientRequest', () => {
       expect(fetchData).toEqual(expect.any(Function))
       expect(state).toEqual({ cacheHit: false, loading: false })
     })
+
+    it('sets loading to false if isManual is passed in', () => {
+      let fetchData, state
+      renderHook(
+        () =>
+          ([fetchData, state] = useClientRequest(TEST_QUERY, {
+            isManual: true
+          })),
+        {
+          wrapper: Wrapper
+        }
+      )
+      expect(fetchData).toEqual(expect.any(Function))
+      expect(state).toEqual({ cacheHit: false, loading: false })
+    })
   })
 
   describe('fetchData', () => {

--- a/packages/graphql-hooks/test/unit/useManualQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useManualQuery.test.js
@@ -13,7 +13,8 @@ describe('useManualQuery', () => {
     useManualQuery(TEST_QUERY, { option: 'option' })
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       useCache: true,
-      option: 'option'
+      option: 'option',
+      isManual: true
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Calling `useManualQuery` currently returns a state with `loading` set to _true_, despite the request function not having been called.  This PR updates the initial state for manual queries to default to _false_.

Resolves https://github.com/nearform/graphql-hooks/issues/133.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests

### Notes
- My implementation simply adds another option field `isManual` to identify the type of request being made, which is quite similar to the `isMutation` field in terms of usage. An alternative (but potentially more restrictive) approach would be to replace the two options with something to indicate the request will not immediately get called, e.g. `isDeferred`.  Please let me know if such an approach would be preferred.  