### PR TITLE
feat: add a TypeScript declaration file for graphql-hooks-memcache

### DIFF
--- a/packages/graphql-hooks-memcache/index.d.ts
+++ b/packages/graphql-hooks-memcache/index.d.ts
@@ -1,0 +1,16 @@
+export = MemCacheFunction
+
+declare function MemCacheFunction(options?: {
+  size?: number
+  ttl?: number
+  initialState?: object
+}): MemCache
+
+interface MemCache {
+  get(keyObject: object): object
+  set(keyObject: object, data: object): void
+  delete(keyObject: object): void
+  clear(): void
+  keys(): void
+  getInitialState(): object
+}

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -5,6 +5,7 @@
   "main": "lib/graphql-hooks-memcache.js",
   "module": "es/graphql-hooks-memcache.js",
   "unpkg": "dist/graphql-hooks-memcache.min.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "../../node_modules/.bin/rollup -c",
@@ -14,7 +15,8 @@
     "dist",
     "es",
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "keywords": [
     "graphql",


### PR DESCRIPTION
### What does this PR do?

Adds a [https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) for `graphql-hooks-memcache` that will be published to npm, so that the package works well with TypeScript.

### Related issues

#91 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
