### PR TITLE
feat: add a TypeScript declaration file for graphql-hooks-ssr

### DIFF
--- a/packages/graphql-hooks-ssr/index.d.ts
+++ b/packages/graphql-hooks-ssr/index.d.ts
@@ -1,0 +1,18 @@
+import { ElementType } from 'react'
+
+export function getInitialState(options: Options): object
+
+interface Options {
+  App: ElementType
+  client: Client
+  render?(element: ElementType): string
+}
+
+interface Client {
+  cache: Cache
+  ssrPromises?: Promise<any>[]
+}
+
+interface Cache {
+  getInitialState(): object
+}

--- a/packages/graphql-hooks-ssr/package.json
+++ b/packages/graphql-hooks-ssr/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.7",
   "description": "Server side rendering utils for graphql-hooks",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
     "prepublishOnly": "cp ../../LICENSE ."
@@ -23,6 +24,7 @@
     "react-dom": "^16.8.1"
   },
   "devDependencies": {
+    "@types/react": "16.8.8",
     "react": "16.8.4",
     "react-dom": "16.8.4"
   },


### PR DESCRIPTION
### What does this PR do?

Adds a [https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) for `graphql-hooks-ssr` that will be published to npm, so that the package works well with TypeScript.

You can test this out locally by rebasing on #136, rebuilding everything & looking at `examples/typescript` in your IDE.

### Related issues

Resolves #91 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
