### PR TITLE
Fix type declarations for logErrorResult & onError

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -20,7 +20,7 @@ export class GraphQLClient {
   ): CacheKeyObject
   setHeader(key: string, value: string): GraphQLClient
   setHeaders(headers: Headers): GraphQLClient
-  logErrorResult({ result: Result, operation: Operation }): void
+  logErrorResult({ result, operation }: { result: Result, operation: Operation }): void
   request(operation: Operation, options: object): Promise<Result>
 }
 
@@ -56,7 +56,7 @@ interface ClientOptions {
   fetch?(url: string, options?: object): Promise<object>
   fetchOptions?: object
   logErrors?: boolean
-  onError?({ operation: Operation, result: Result }): void
+  onError?({ result, operation }: { operation: Operation, result: Result }): void
 }
 
 type Headers = { [k: string]: string }


### PR DESCRIPTION
The following throws without the propper type declarations when using `graphql-hooks` with typescript:
```
ERROR in [at-loader] ./node_modules/graphql-hooks/index.d.ts:44:25
    TS7031: Binding element 'Operation' implicitly has an 'any' type.

ERROR in [at-loader] ./node_modules/graphql-hooks/index.d.ts:44:44
    TS7031: Binding element 'Result' implicitly has an 'any' type.
```

### What does this PR do?

Fixes type errors when using typescript.

### Related issues

<!-- Link to any related issues here -->

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
