### PR TITLE
String warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ function MyComponent() {
 
 A lot of options can be carried over as-is, or have direct replacements:
 
-- `query` ➡️ `useQuery(query)`: No need to wrap the query in `gql`
+- `query` ➡️ `useQuery(query)`: Remove any usage of `gql` and pass your queries as strings.
 - `variables` ➡️ `useQuery(query, { variables })`
 - `ssr` ➡️ `useQuery(query, { ssr })`
 - **Fetch Policies**: See [#75](https://github.com/nearform/graphql-hooks/issues/75) for more info

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -51,6 +51,13 @@ function reducer(state, action) {
   opts.skipCache: Boolean
 */
 function useClientRequest(query, initialOpts = {}) {
+  if (typeof query !== 'string') {
+    /* eslint-disable-next-line no-console */
+    console.warn(
+      'Your query must be a string. If you are using the `gql` template literal from graphql-tag, remove it from your query.'
+    )
+  }
+
   const client = React.useContext(ClientContext)
   const isMounted = React.useRef(true)
   const activeCacheKey = React.useRef(null)

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -52,8 +52,7 @@ function reducer(state, action) {
 */
 function useClientRequest(query, initialOpts = {}) {
   if (typeof query !== 'string') {
-    /* eslint-disable-next-line no-console */
-    console.warn(
+    throw new Error(
       'Your query must be a string. If you are using the `gql` template literal from graphql-tag, remove it from your query.'
     )
   }

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -112,6 +112,29 @@ describe('useClientRequest', () => {
     })
   })
 
+  it('warns the user if the supplied query is not a string', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    renderHook(
+      () =>
+        useClientRequest(
+          {},
+          {
+            updateData: () => {}
+          }
+        ),
+      {
+        wrapper: Wrapper
+      }
+    )
+    /* eslint-disable-next-line no-console */
+    expect(console.warn.mock.calls[0][0]).toMatch(
+      /^Your query must be a string/
+    )
+    /* eslint-disable-next-line no-console */
+    console.warn.mockRestore()
+  })
+
   describe('race conditions', () => {
     it('dispatches only second result if second response is faster than first', async () => {
       const res1 = new Promise(resolve =>

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -112,27 +112,13 @@ describe('useClientRequest', () => {
     })
   })
 
-  it('warns the user if the supplied query is not a string', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
-
-    renderHook(
-      () =>
-        useClientRequest(
-          {},
-          {
-            updateData: () => {}
-          }
-        ),
-      {
-        wrapper: Wrapper
-      }
-    )
-    /* eslint-disable-next-line no-console */
-    expect(console.warn.mock.calls[0][0]).toMatch(
+  it('throws if the supplied query is not a string', () => {
+    const rendered = renderHook(() => useClientRequest({}), {
+      wrapper: Wrapper
+    })
+    expect(rendered.result.error.message).toMatch(
       /^Your query must be a string/
     )
-    /* eslint-disable-next-line no-console */
-    console.warn.mockRestore()
   })
 
   describe('race conditions', () => {


### PR DESCRIPTION
### What does this PR do?

Warns the user if they are passing in a query that is not a string. A common case might be if users use the `gql` template literal from graphql-tag on their queries.

### Related issues

#197 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
