### PR TITLE
fix: memoize callback for fetchData

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -60,13 +60,14 @@ function useClientRequest(query, initialOpts = {}) {
   const client = React.useContext(ClientContext)
   const isMounted = React.useRef(true)
   const activeCacheKey = React.useRef(null)
-  const operation = {
+  const operation = React.useRef(null)
+  operation.current = {
     query,
     variables: initialOpts.variables,
     operationName: initialOpts.operationName
   }
 
-  const cacheKey = client.getCacheKey(operation, initialOpts)
+  const cacheKey = client.getCacheKey(operation.current, initialOpts)
   const isDeferred = initialOpts.isMutation || initialOpts.isManual
   const initialCacheHit =
     initialOpts.skipCache || !client.cache ? null : client.cache.get(cacheKey)
@@ -95,64 +96,76 @@ function useClientRequest(query, initialOpts = {}) {
     }
   }, [])
 
+  const latestInitialOpts = React.useRef(null)
+  latestInitialOpts.current = initialOpts
+
+  const latestStateData = React.useRef(null)
+  latestStateData.current = state.data
+
   // arguments to fetchData override the useClientRequest arguments
-  function fetchData(newOpts) {
-    if (!isMounted.current) return Promise.resolve()
-    const revisedOpts = {
-      ...initialOpts,
-      ...newOpts
-    }
-
-    const revisedOperation = {
-      ...operation,
-      variables: revisedOpts.variables,
-      operationName: revisedOpts.operationName
-    }
-
-    const revisedCacheKey = client.getCacheKey(revisedOperation, revisedOpts)
-
-    // NOTE: There is a possibility of a race condition whereby
-    // the second query could finish before the first one, dispatching an old result
-    // see https://github.com/nearform/graphql-hooks/issues/150
-    activeCacheKey.current = revisedCacheKey
-
-    const cacheHit =
-      revisedOpts.skipCache || !client.cache
-        ? null
-        : client.cache.get(revisedCacheKey)
-
-    if (cacheHit) {
-      dispatch({
-        type: actionTypes.CACHE_HIT,
-        result: cacheHit
-      })
-
-      return Promise.resolve(cacheHit)
-    }
-
-    dispatch({ type: actionTypes.LOADING })
-    return client.request(revisedOperation, revisedOpts).then(result => {
-      if (state.data && result.data && revisedOpts.updateData) {
-        if (typeof revisedOpts.updateData !== 'function') {
-          throw new Error('options.updateData must be a function')
-        }
-        result.data = revisedOpts.updateData(state.data, result.data)
+  const fetchData = React.useCallback(
+    newOpts => {
+      if (!isMounted.current) return Promise.resolve()
+      const revisedOpts = {
+        ...latestInitialOpts.current,
+        ...newOpts
       }
 
-      if (revisedOpts.useCache && client.cache) {
-        client.cache.set(revisedCacheKey, result)
+      const revisedOperation = {
+        ...operation.current,
+        variables: revisedOpts.variables,
+        operationName: revisedOpts.operationName
       }
 
-      if (isMounted.current && revisedCacheKey === activeCacheKey.current) {
+      const revisedCacheKey = client.getCacheKey(revisedOperation, revisedOpts)
+
+      // NOTE: There is a possibility of a race condition whereby
+      // the second query could finish before the first one, dispatching an old result
+      // see https://github.com/nearform/graphql-hooks/issues/150
+      activeCacheKey.current = revisedCacheKey
+
+      const cacheHit =
+        revisedOpts.skipCache || !client.cache
+          ? null
+          : client.cache.get(revisedCacheKey)
+
+      if (cacheHit) {
         dispatch({
-          type: actionTypes.REQUEST_RESULT,
-          result
+          type: actionTypes.CACHE_HIT,
+          result: cacheHit
         })
+
+        return Promise.resolve(cacheHit)
       }
 
-      return result
-    })
-  }
+      dispatch({ type: actionTypes.LOADING })
+      return client.request(revisedOperation, revisedOpts).then(result => {
+        if (latestStateData.current && result.data && revisedOpts.updateData) {
+          if (typeof revisedOpts.updateData !== 'function') {
+            throw new Error('options.updateData must be a function')
+          }
+          result.data = revisedOpts.updateData(
+            latestStateData.current,
+            result.data
+          )
+        }
+
+        if (revisedOpts.useCache && client.cache) {
+          client.cache.set(revisedCacheKey, result)
+        }
+
+        if (isMounted.current && revisedCacheKey === activeCacheKey.current) {
+          dispatch({
+            type: actionTypes.REQUEST_RESULT,
+            result
+          })
+        }
+
+        return result
+      })
+    },
+    [client]
+  )
 
   return [fetchData, state]
 }

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -441,6 +441,22 @@ describe('useClientRequest', () => {
       })
     })
 
+    it('returns the same function on every render', () => {
+      const fetchDataArr = []
+      const { rerender } = renderHook(
+        () => {
+          const [fetchData] = useClientRequest(TEST_QUERY, { useCache: true })
+          fetchDataArr.push(fetchData)
+        },
+        { wrapper: Wrapper }
+      )
+
+      rerender()
+
+      expect(typeof fetchDataArr[0]).toBe('function')
+      expect(fetchDataArr[0]).toBe(fetchDataArr[1])
+    })
+
     describe('options.updateData', () => {
       it('is called with old & new data if the data has changed & the result is returned', async () => {
         let fetchData, state


### PR DESCRIPTION
### What does this PR do?

Memoize returned function from useMutation and useManualQuery so it can be used in useEffect as a  dependency. Consider this example:

```jsx
const [shouldFetch, setShouldFetch] = useState(false)
const [fetchUser] = useManualQuery(GET_USER_QUERY)

useEffect(() => {
  if (shouldFetch) {
    fetchUser()
  }
}, [fetchUser, shouldFetch])

return <button onClick={() => setShouldFetch(true)} />
``` 

When button is clicked we expect only one request. But because fetchUser is not memoized internally, we get lots of requests and infinite render.

### Related issues

https://github.com/nearform/graphql-hooks/issues/234

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
