### PR TITLE
Allow to remove header

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ const client = new GraphQLClient(config)
 
 - `client.setHeader(key, value)`: Updates `client.headers` adding the new header to the existing headers
 - `client.setHeaders(headers)`: Replaces `client.headers`
+- `client.removeHeader(key)`: Updates `client.headers` removing the header if it exists
 - `client.logErrorResult({ operation, result })`: Default error logger; useful if you'd like to use it inside your custom `onError` handler
 - `request(operation, options)`: Make a request to your GraphQL server; returning a Promise
   - `operation`: Object with `query`, `variables` and `operationName`

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -20,6 +20,7 @@ export class GraphQLClient {
   ): CacheKeyObject
   setHeader(key: string, value: string): GraphQLClient
   setHeaders(headers: Headers): GraphQLClient
+  removeHeader(key: string): GraphQLClient
   logErrorResult({
     result,
     operation

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -39,6 +39,11 @@ class GraphQLClient {
     this.headers = headers
     return this
   }
+
+  removeHeader(key) {
+    delete this.headers[key]
+    return this
+  }
   /* eslint-disable no-console */
   logErrorResult({ result, operation }) {
     if (this.onError) {

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -106,10 +106,20 @@ describe('GraphQLClient', () => {
 
   describe('setHeaders', () => {
     it('replaces all headers', () => {
-      const headers = { 'My-Header': 'hello ' }
+      const headers = { 'My-Header': 'hello' }
       const client = new GraphQLClient({ ...validConfig })
       client.setHeaders(headers)
       expect(client.headers).toBe(headers)
+    })
+  })
+
+  describe('removeHeader', () => {
+    it('removes the key', () => {
+      const headers = { 'My-Header': 'hello' }
+      const client = new GraphQLClient({ ...validConfig, headers })
+      expect(client.headers['My-Header']).toBe('hello')
+      client.removeHeader('My-Header')
+      expect(client.headers).not.toHaveProperty('My-Header')
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Allows to remove a previously set header from `GraphQLClient`.

### Related issues

Closes #247.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
