### PR TITLE
chore(deps): replace react-testing-library with @testing-library/react

### DIFF
--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -37,7 +37,7 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-hooks-testing-library": "0.4.1",
-    "react-testing-library": "7.0.1"
+    "@testing-library/react": "8.0.1"
   },
   "repository": {
     "type": "git",

--- a/packages/graphql-hooks/test/integration/useQuery.test.js
+++ b/packages/graphql-hooks/test/integration/useQuery.test.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { render, waitForElement } from 'react-testing-library'
+import { render, waitForElement } from '@testing-library/react'
 import { GraphQLClient, ClientContext, useQuery } from '../../src'
 
 let testComponentRenderCount = 0

--- a/packages/graphql-hooks/test/setupAfterEnv.js
+++ b/packages/graphql-hooks/test/setupAfterEnv.js
@@ -1,1 +1,1 @@
-afterEach(require('react-testing-library').cleanup)
+afterEach(require('@testing-library/react').cleanup)


### PR DESCRIPTION
### What does this PR do?

react-testing-library has been deprecated and replaced by the new version of @testing-library/react.

### Related issues
N/A

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
