### PR TITLE
chore(CI): adds queuing step in acceptance-tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+orbs:
+  queue: eddiewebb/queue@1.1.2
 jobs:
   build:
     working_directory: ~/graphql-hooks
@@ -55,6 +57,8 @@ jobs:
           paths:
             - node_modules
 
+      - queue/until_front_of_line:
+          consider-branch: false
       - run: npm run test:acceptance:ci
 
       - store_test_results:


### PR DESCRIPTION
### What does this PR do?
The free version of browserstack.com is giving a limited number of free runners. If we have multiple PRs pending from renovatebot we initiate acceptance tests runners at the same time. That causes the job to fail since we run out of the browserstack runners.

With CircleCI queue orb we can pause the step and wait for other jobs to complete. As a result, we should not have acceptance-tests running concurrently.

The downside of this is that the execution time for every job might be very different.

### Related issues

N/A

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)