### PR TITLE
chore: updates renovate config to include examples dir

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [],
+  "includePaths": [
+    "package.json",
+    "packages/**",
+    "examples/**"
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Renovate bot is not checking `example/**/package.json` projects since they are ignored after inheriting `ignorePaths` list that includes `examples/**`. I did experiment having an explicit packagePaths property for examples folders but nothing seemed to work. The only option was to set `ignorePaths` to the empty list. I added `includePaths` to make it more efficient to scan only defined folders.

### Related issues

- https://github.com/nearform/graphql-hooks/issues/178

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests