### PR TITLE
chore(CI): updates CircleCI config to 2.1 to get availability of Circle CI orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,3 +63,8 @@ jobs:
 
       - store_test_results:
           path: /tmp/acceptance-test-results
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - acceptance-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-# Javascript Node CircleCI 2.0 configuration file
+# Javascript Node CircleCI 2.1 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 orbs:
   queue: eddiewebb/queue@1.1.2
 jobs:


### PR DESCRIPTION
### What does this PR do?

A missing bit to enable Circle CI orbs. Also, Circle CI orbs have been enabled at organizational level so now the builds should pass.

### Related issues

N/A

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
