### PR TITLE
Memoise fetchData callback

### DIFF
--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -32,6 +32,9 @@
   "peerDependencies": {
     "react": "^16.8.1"
   },
+  "dependencies": {
+    "dequal": "^1.0.0"
+  },
   "devDependencies": {
     "@testing-library/react": "8.0.1",
     "jest-fetch-mock": "2.1.2",

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -524,5 +524,46 @@ describe('useClientRequest', () => {
         )
       })
     })
+
+    describe('memoisation', () => {
+      it('returns the same function on every render if query and options remain the same', () => {
+        const fetchDataArr = []
+        const { rerender } = renderHook(
+          () => {
+            const [fetchData] = useClientRequest(TEST_QUERY, {
+              variables: { test: 1 }
+            })
+            fetchDataArr.push(fetchData)
+          },
+          { wrapper: Wrapper }
+        )
+
+        rerender()
+
+        expect(typeof fetchDataArr[0]).toBe('function')
+        expect(fetchDataArr[0]).toBe(fetchDataArr[1])
+      })
+
+      it('returns a new function if query or options change', () => {
+        const fetchDataArr = []
+
+        const { rerender } = renderHook(
+          ({ variables }) => {
+            const [fetchData] = useClientRequest(TEST_QUERY, { variables })
+            fetchDataArr.push(fetchData)
+          },
+          {
+            initialProps: { variables: { test: 1 } },
+            wrapper: Wrapper
+          }
+        )
+
+        rerender({ variables: { test: 2 } })
+
+        expect(typeof fetchDataArr[0]).toBe('function')
+        expect(typeof fetchDataArr[1]).toBe('function')
+        expect(fetchDataArr[0]).not.toBe(fetchDataArr[1])
+      })
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Memoises `fetchData` callback (function returned by `useMutation` and `useManualQuery`).

This is based on the work of @lynxtaa in #235 (who I credited in the commit), but uses a different strategy. In essence, it does a deep compare of the dependencies to `useCallback` between renders, to determine if they really changed. This is necessary because some of those dependencies are not primitive values but objects.

### Related issues

Fixes #234.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
