### PR TITLE
fix: memoize useManualQuery and useMutation if no options passed

### DIFF
--- a/packages/graphql-hooks/src/index.js
+++ b/packages/graphql-hooks/src/index.js
@@ -1,13 +1,20 @@
+import { useMemo } from 'react'
 import ClientContext from './ClientContext'
 import GraphQLClient from './GraphQLClient'
 import useClientRequest from './useClientRequest'
 import useQuery from './useQuery'
 
 const useManualQuery = (query, options) =>
-  useClientRequest(query, { useCache: true, isManual: true, ...options })
+  useClientRequest(
+    query,
+    useMemo(() => ({ useCache: true, isManual: true, ...options }), [options])
+  )
 
 const useMutation = (query, options) =>
-  useClientRequest(query, { isMutation: true, ...options })
+  useClientRequest(
+    query,
+    useMemo(() => ({ isMutation: true, ...options }), [options])
+  )
 
 export {
   ClientContext,

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -42,6 +42,9 @@ function reducer(state, action) {
   }
 }
 
+// needed for hooks memoization
+const defaultInitialOpts = {}
+
 /*
   options include:
 
@@ -50,7 +53,7 @@ function reducer(state, action) {
   opts.fetchOptionsOverrides: Object
   opts.skipCache: Boolean
 */
-function useClientRequest(query, initialOpts = {}) {
+function useClientRequest(query, initialOpts = defaultInitialOpts) {
   if (typeof query !== 'string') {
     throw new Error(
       'Your query must be a string. If you are using the `gql` template literal from graphql-tag, remove it from your query.'
@@ -60,11 +63,15 @@ function useClientRequest(query, initialOpts = {}) {
   const client = React.useContext(ClientContext)
   const isMounted = React.useRef(true)
   const activeCacheKey = React.useRef(null)
-  const operation = {
-    query,
-    variables: initialOpts.variables,
-    operationName: initialOpts.operationName
-  }
+
+  const operation = React.useMemo(
+    () => ({
+      query,
+      variables: initialOpts.variables,
+      operationName: initialOpts.operationName
+    }),
+    [initialOpts.operationName, initialOpts.variables, query]
+  )
 
   const cacheKey = client.getCacheKey(operation, initialOpts)
   const isDeferred = initialOpts.isMutation || initialOpts.isManual
@@ -95,64 +102,73 @@ function useClientRequest(query, initialOpts = {}) {
     }
   }, [])
 
+  const latestStateData = React.useRef(null)
+  latestStateData.current = state.data
+
   // arguments to fetchData override the useClientRequest arguments
-  function fetchData(newOpts) {
-    if (!isMounted.current) return Promise.resolve()
-    const revisedOpts = {
-      ...initialOpts,
-      ...newOpts
-    }
-
-    const revisedOperation = {
-      ...operation,
-      variables: revisedOpts.variables,
-      operationName: revisedOpts.operationName
-    }
-
-    const revisedCacheKey = client.getCacheKey(revisedOperation, revisedOpts)
-
-    // NOTE: There is a possibility of a race condition whereby
-    // the second query could finish before the first one, dispatching an old result
-    // see https://github.com/nearform/graphql-hooks/issues/150
-    activeCacheKey.current = revisedCacheKey
-
-    const cacheHit =
-      revisedOpts.skipCache || !client.cache
-        ? null
-        : client.cache.get(revisedCacheKey)
-
-    if (cacheHit) {
-      dispatch({
-        type: actionTypes.CACHE_HIT,
-        result: cacheHit
-      })
-
-      return Promise.resolve(cacheHit)
-    }
-
-    dispatch({ type: actionTypes.LOADING })
-    return client.request(revisedOperation, revisedOpts).then(result => {
-      if (state.data && result.data && revisedOpts.updateData) {
-        if (typeof revisedOpts.updateData !== 'function') {
-          throw new Error('options.updateData must be a function')
-        }
-        result.data = revisedOpts.updateData(state.data, result.data)
+  const fetchData = React.useCallback(
+    newOpts => {
+      if (!isMounted.current) return Promise.resolve()
+      const revisedOpts = {
+        ...initialOpts,
+        ...newOpts
       }
 
-      if (revisedOpts.useCache && client.cache) {
-        client.cache.set(revisedCacheKey, result)
+      const revisedOperation = {
+        ...operation,
+        variables: revisedOpts.variables,
+        operationName: revisedOpts.operationName
       }
 
-      if (isMounted.current && revisedCacheKey === activeCacheKey.current) {
+      const revisedCacheKey = client.getCacheKey(revisedOperation, revisedOpts)
+
+      // NOTE: There is a possibility of a race condition whereby
+      // the second query could finish before the first one, dispatching an old result
+      // see https://github.com/nearform/graphql-hooks/issues/150
+      activeCacheKey.current = revisedCacheKey
+
+      const cacheHit =
+        revisedOpts.skipCache || !client.cache
+          ? null
+          : client.cache.get(revisedCacheKey)
+
+      if (cacheHit) {
         dispatch({
-          type: actionTypes.REQUEST_RESULT,
-          result
+          type: actionTypes.CACHE_HIT,
+          result: cacheHit
         })
+
+        return Promise.resolve(cacheHit)
       }
 
-      return result
-    })
-  }
+      dispatch({ type: actionTypes.LOADING })
+      return client.request(revisedOperation, revisedOpts).then(result => {
+        if (latestStateData.current && result.data && revisedOpts.updateData) {
+          if (typeof revisedOpts.updateData !== 'function') {
+            throw new Error('options.updateData must be a function')
+          }
+          result.data = revisedOpts.updateData(
+            latestStateData.current,
+            result.data
+          )
+        }
+
+        if (revisedOpts.useCache && client.cache) {
+          client.cache.set(revisedCacheKey, result)
+        }
+
+        if (isMounted.current && revisedCacheKey === activeCacheKey.current) {
+          dispatch({
+            type: actionTypes.REQUEST_RESULT,
+            result
+          })
+        }
+
+        return result
+      })
+    },
+    [client, initialOpts, operation]
+  )
 
   return [fetchData, state]
 }

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -441,6 +441,38 @@ describe('useClientRequest', () => {
       })
     })
 
+    it('returns the same function on every render if NO initial options are passed', () => {
+      const fetchDataArr = []
+      const { rerender } = renderHook(
+        () => {
+          const [fetchData] = useClientRequest(TEST_QUERY)
+          fetchDataArr.push(fetchData)
+        },
+        { wrapper: Wrapper }
+      )
+
+      rerender()
+
+      expect(typeof fetchDataArr[0]).toBe('function')
+      expect(fetchDataArr[0]).toBe(fetchDataArr[1])
+    })
+
+    it('returns different function on every render if initial options are passed', () => {
+      const fetchDataArr = []
+      const { rerender } = renderHook(
+        () => {
+          const [fetchData] = useClientRequest(TEST_QUERY, { variables: {} })
+          fetchDataArr.push(fetchData)
+        },
+        { wrapper: Wrapper }
+      )
+
+      rerender()
+
+      expect(typeof fetchDataArr[0]).toBe('function')
+      expect(fetchDataArr[0]).not.toBe(fetchDataArr[1])
+    })
+
     describe('options.updateData', () => {
       it('is called with old & new data if the data has changed & the result is returned', async () => {
         let fetchData, state

--- a/packages/graphql-hooks/test/unit/useManualQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useManualQuery.test.js
@@ -1,3 +1,4 @@
+import { renderHook } from 'react-hooks-testing-library'
 import { useManualQuery, useClientRequest } from '../../src'
 
 jest.mock('../../src/useClientRequest')
@@ -10,7 +11,7 @@ const TEST_QUERY = `query Test($limit: Int) {
 
 describe('useManualQuery', () => {
   it('calls useClientRequest with useCache set to true & options', () => {
-    useManualQuery(TEST_QUERY, { option: 'option' })
+    renderHook(() => useManualQuery(TEST_QUERY, { option: 'option' }))
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       useCache: true,
       option: 'option',

--- a/packages/graphql-hooks/test/unit/useMutation.test.js
+++ b/packages/graphql-hooks/test/unit/useMutation.test.js
@@ -1,3 +1,4 @@
+import { renderHook } from 'react-hooks-testing-library'
 import { useMutation, useClientRequest } from '../../src'
 
 jest.mock('../../src/useClientRequest')
@@ -10,7 +11,7 @@ const TEST_QUERY = `query Test($limit: Int) {
 
 describe('useMutation', () => {
   it('calls useClientRequest with options and isMutation set to true', () => {
-    useMutation(TEST_QUERY, { option: 'option' })
+    renderHook(() => useMutation(TEST_QUERY, { option: 'option' }))
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       isMutation: true,
       option: 'option'


### PR DESCRIPTION
### What does this PR do?

If no initial options are passed, memoize function returned from useMutation and useManualQuery. As a result this function can be used in effects without causing infinite rerenders. Consider this example:

```jsx
const [shouldFetch, setShouldFetch] = useState(false)
const [fetchUser] = useManualQuery(GET_USER_QUERY)

useEffect(() => {
  if (shouldFetch) {
    fetchUser()
  }
}, [fetchUser, shouldFetch])

return <button onClick={() => setShouldFetch(true)} />
``` 

When button is clicked we expect only one request. But because fetchUser is not memoized internally, we get lots of requests and infinite render.

**Why proposed solution only works when no initial options are passed?**  I think this solution is the most straightforward. Memoization is tricky  and requires deep equality checks (also options may contain functions like `fetchOptionsOverrides` and `updateData`). And we can always pass these options when calling a memoized function. 

### Related issues

https://github.com/nearform/graphql-hooks/issues/234

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests