### PR TITLE
Changed 'endpoint' to 'url' in example

### DIFF
--- a/packages/graphql-hooks-memcache/README.md
+++ b/packages/graphql-hooks-memcache/README.md
@@ -19,7 +19,7 @@ import { GraphQLClient } from 'graphql-hooks'
 import memCache from 'graphql-hooks-memcache'
 
 const client = new GraphQLClient({
-  endpoint: '/graphql',
+  url: '/graphql',
   cache: memCache()
 })
 ```


### PR DESCRIPTION
### What does this PR do?

In your `graphql-hooks-memcache` example, you specified `endpoint` instead of `url` for the GraphQL Client. I believe it needs to be `url`.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
