### PR TITLE
fix: reset state with an error immediately on data refetch

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -14,6 +14,14 @@ function reducer(state, action) {
     case actionTypes.RESET_STATE:
       return action.initialState
     case actionTypes.LOADING:
+      // if previous action resulted in error - refetch will reset the state
+      if (state.error) {
+        return {
+          ...action.initialState,
+          data: state.data,
+          loading: true
+        }
+      }
       if (state.loading) {
         return state // saves a render cycle as state is the same
       }
@@ -145,7 +153,7 @@ function useClientRequest(query, initialOpts = {}) {
         return Promise.resolve(cacheHit)
       }
 
-      dispatch({ type: actionTypes.LOADING })
+      dispatch({ type: actionTypes.LOADING, initialState })
       return client.request(revisedOperation, revisedOpts).then(result => {
         if (
           revisedOpts.updateData &&


### PR DESCRIPTION
### What does this PR do?

Once we go into the loading state we can check if the previous state includes any error, if so we reset it to the initial state.

### Related issues

Solves https://github.com/nearform/graphql-hooks/issues/313

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant tests