### PR TITLE
chore: move to use @testing-library/react-hooks

### DIFF
--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -38,11 +38,11 @@
   },
   "devDependencies": {
     "@testing-library/react": "^8.0.1",
+    "@testing-library/react-hooks": "^1.1.0",
     "formdata-node": "^1.6.0",
     "jest-fetch-mock": "^2.1.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-hooks-testing-library": "^0.6.0",
     "react-test-renderer": "^16.8.6"
   },
   "repository": {

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { renderHook } from 'react-hooks-testing-library'
+import { renderHook } from '@testing-library/react-hooks'
 import { useClientRequest, ClientContext } from '../../src'
 
 let mockClient

--- a/packages/graphql-hooks/test/unit/useQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useQuery.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { renderHook } from 'react-hooks-testing-library'
+import { renderHook } from '@testing-library/react-hooks'
 import { ClientContext, useQuery, useClientRequest } from '../../src'
 
 jest.mock('../../src/useClientRequest')


### PR DESCRIPTION
### What does this PR do?

`react-hooks-testing-library` advised to move to `@testing-library/react-hooks`, so that's what this PR does.

### Related issues

<!-- Link to any related issues here -->

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
