### PR TITLE
Add support for generic Variables TS type (#348)

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -24,32 +24,32 @@ export class GraphQLClient {
     result: Result
     operation: Operation
   }): void
-  getCacheKey(
+  getCacheKey<Variables = object>(
     operation: Operation,
-    options: UseClientRequestOptions
+    options: UseClientRequestOptions<Variables>
   ): CacheKeyObject
   getFetchOptions(operation: Operation, fetchOptionsOverrides?: object): object
   request(operation: Operation, options: object): Promise<Result>
 }
 
-export function useClientRequest<ResponseData = any>(
+export function useClientRequest<ResponseData = any, Variables = object>(
   query: string,
-  options?: UseClientRequestOptions
+  options?: UseClientRequestOptions<Variables>
 ): [FetchData<ResponseData>, UseClientRequestResult<ResponseData>]
 
-export function useQuery<ResponseData = any>(
+export function useQuery<ResponseData = any, Variables = object>(
   query: string,
-  options?: UseQueryOptions
-): UseQueryResult<ResponseData>
+  options?: UseQueryOptions<Variables>
+): UseQueryResult<ResponseData, Variables>
 
-export function useManualQuery<ResponseData = any>(
+export function useManualQuery<ResponseData = any, Variables = object>(
   query: string,
-  options?: UseClientRequestOptions
+  options?: UseClientRequestOptions<Variables>
 ): [FetchData<ResponseData>, UseClientRequestResult<ResponseData>]
 
-export function useMutation<ResponseData = any>(
+export function useMutation<ResponseData = any, Variables = object>(
   query: string,
-  options?: UseClientRequestOptions
+  options?: UseClientRequestOptions<Variables>
 ): [FetchData<ResponseData>, UseClientRequestResult<ResponseData>]
 
 export const ClientContext: React.Context<GraphQLClient>
@@ -107,18 +107,19 @@ interface Result {
   error?: APIError
 }
 
-interface UseClientRequestOptions {
+interface UseClientRequestOptions<Variables = object> {
   useCache?: boolean
   isMutation?: boolean
   isManual?: boolean
-  variables?: object
+  variables?: Variables
   operationName?: string
   skipCache?: boolean
   fetchOptionsOverrides?: object
   updateData?(previousData: any, data: any): any
 }
 
-interface UseQueryOptions extends UseClientRequestOptions {
+interface UseQueryOptions<Variables>
+  extends UseClientRequestOptions<Variables> {
   ssr?: boolean
 }
 
@@ -129,15 +130,15 @@ interface UseClientRequestResult<ResponseData> {
   error?: APIError
 }
 
-interface UseQueryResult<ResponseData>
+interface UseQueryResult<ResponseData, Variables>
   extends UseClientRequestResult<ResponseData> {
   refetch(
-    options?: UseQueryOptions
+    options?: UseQueryOptions<Variables>
   ): Promise<UseClientRequestResult<ResponseData>>
 }
 
-type FetchData<ResponseData> = (
-  options?: UseClientRequestOptions
+type FetchData<ResponseData, Variables = object> = (
+  options?: UseClientRequestOptions<Variables>
 ) => Promise<UseClientRequestResult<ResponseData>>
 
 interface CacheKeyObject {


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in generic type for variables in a GraphQL operation.

**Before**

```tsx
interface QueryData {
  projectName: string;
}

useQuery<QueryData>(PROJECT_QUERY, {
   variables: {
      teamId: 'someString'
   },
});
```

**After**

```tsx
interface QueryData {
  projectName: string;
}

interface QueryVariables {
  teamId: string;
}

useQuery<QueryData, QueryVariables>(PROJECT_QUERY, {
  // options.variables is now of type QueryVariables
   variables: {
      teamId: 'someString'
   },
});
```

### Related issues

- [x] #348 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests