### PR TITLE
Swap tiny-lru with lru-cache, tiny-lru causing import error

### DIFF
--- a/packages/graphql-hooks-memcache/.size-snapshot.json
+++ b/packages/graphql-hooks-memcache/.size-snapshot.json
@@ -1,46 +1,46 @@
 {
   "lib/graphql-hooks-memcache.js": {
-    "bundled": 936,
-    "minified": 621,
-    "gzipped": 369
+    "bundled": 989,
+    "minified": 666,
+    "gzipped": 396
   },
   "es/graphql-hooks-memcache.js": {
-    "bundled": 763,
-    "minified": 490,
-    "gzipped": 311,
+    "bundled": 816,
+    "minified": 535,
+    "gzipped": 339,
     "treeshaked": {
       "rollup": {
-        "code": 45,
-        "import_statements": 45
+        "code": 68,
+        "import_statements": 46
       },
       "webpack": {
-        "code": 1062
+        "code": 1085
       }
     }
   },
   "es/graphql-hooks-memcache.mjs": {
-    "bundled": 2080,
-    "minified": 2076,
-    "gzipped": 886,
+    "bundled": 1706,
+    "minified": 1706,
+    "gzipped": 725,
     "treeshaked": {
       "rollup": {
-        "code": 1471,
+        "code": 22,
         "import_statements": 0
       },
       "webpack": {
-        "code": 2521
+        "code": 1121
       }
     }
   },
   "dist/graphql-hooks-memcache.js": {
-    "bundled": 4451,
-    "minified": 2281,
-    "gzipped": 973
+    "bundled": 3427,
+    "minified": 1911,
+    "gzipped": 835
   },
   "dist/graphql-hooks-memcache.min.js": {
-    "bundled": 2277,
-    "minified": 2263,
-    "gzipped": 969
+    "bundled": 1905,
+    "minified": 1897,
+    "gzipped": 824
   },
   "lib\\graphql-hooks-memcache.js": {
     "bundled": 936,

--- a/packages/graphql-hooks-memcache/.size-snapshot.json
+++ b/packages/graphql-hooks-memcache/.size-snapshot.json
@@ -1,46 +1,46 @@
 {
   "lib/graphql-hooks-memcache.js": {
-    "bundled": 989,
-    "minified": 666,
-    "gzipped": 396
+    "bundled": 972,
+    "minified": 643,
+    "gzipped": 383
   },
   "es/graphql-hooks-memcache.js": {
-    "bundled": 816,
-    "minified": 535,
-    "gzipped": 339,
+    "bundled": 799,
+    "minified": 512,
+    "gzipped": 326,
     "treeshaked": {
       "rollup": {
-        "code": 68,
+        "code": 46,
         "import_statements": 46
       },
       "webpack": {
-        "code": 1085
+        "code": 1063
       }
     }
   },
   "es/graphql-hooks-memcache.mjs": {
-    "bundled": 1706,
-    "minified": 1706,
-    "gzipped": 725,
+    "bundled": 8201,
+    "minified": 8178,
+    "gzipped": 2665,
     "treeshaked": {
       "rollup": {
-        "code": 22,
+        "code": 4175,
         "import_statements": 0
       },
       "webpack": {
-        "code": 1121
+        "code": 5489
       }
     }
   },
   "dist/graphql-hooks-memcache.js": {
-    "bundled": 3427,
-    "minified": 1911,
-    "gzipped": 835
+    "bundled": 17537,
+    "minified": 8416,
+    "gzipped": 2759
   },
   "dist/graphql-hooks-memcache.min.js": {
-    "bundled": 1905,
-    "minified": 1897,
-    "gzipped": 824
+    "bundled": 8400,
+    "minified": 8394,
+    "gzipped": 2760
   },
   "lib\\graphql-hooks-memcache.js": {
     "bundled": 936,

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -40,8 +40,5 @@
   "bugs": {
     "url": "https://github.com/nearform/graphql-hooks/issues"
   },
-  "homepage": "https://github.com/nearform/graphql-hooks/blob/master/packages/graphql-hooks-memcache#readme",
-  "devDependencies": {
-    "rollup": "^1.21.4"
-  }
+  "homepage": "https://github.com/nearform/graphql-hooks/blob/master/packages/graphql-hooks-memcache#readme"
 }

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -31,6 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sindresorhus/fnv1a": "^1.2.0",
+    "lru-cache": "^5.1.1",
     "quick-lru": "^4.0.1"
   },
   "repository": {

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -31,8 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sindresorhus/fnv1a": "^1.2.0",
-    "lru-cache": "^5.1.1",
-    "quick-lru": "^4.0.1"
+    "lru-cache": "^5.1.1"
   },
   "repository": {
     "type": "git",

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sindresorhus/fnv1a": "^1.2.0",
-    "tiny-lru": "^6.0.1"
+    "quick-lru": "^4.0.1"
   },
   "repository": {
     "type": "git",
@@ -40,5 +40,8 @@
   "bugs": {
     "url": "https://github.com/nearform/graphql-hooks/issues"
   },
-  "homepage": "https://github.com/nearform/graphql-hooks/blob/master/packages/graphql-hooks-memcache#readme"
+  "homepage": "https://github.com/nearform/graphql-hooks/blob/master/packages/graphql-hooks-memcache#readme",
+  "devDependencies": {
+    "rollup": "^1.21.4"
+  }
 }

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -1,12 +1,12 @@
 import fnv1a from '@sindresorhus/fnv1a'
-import QuickLRU from 'quick-lru'
+import LRU from 'lru-cache'
 
 function generateKey(keyObj) {
   return fnv1a(JSON.stringify(keyObj)).toString(36)
 }
 
-export default function memCache({ size = 100, initialState } = {}) {
-  const lru = new QuickLRU({ maxSize: size })
+export default function memCache({ size = 100, ttl = 0, initialState } = {}) {
+  const lru = new LRU({ maxSize: size, maxAge: ttl })
 
   if (initialState) {
     Object.keys(initialState).map(k => {

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -17,8 +17,8 @@ export default function memCache({ size = 100, ttl = 0, initialState } = {}) {
   return {
     get: keyObj => lru.get(generateKey(keyObj)),
     set: (keyObj, data) => lru.set(generateKey(keyObj), data),
-    delete: keyObj => lru.delete(generateKey(keyObj)),
-    clear: () => lru.clear(),
+    delete: keyObj => lru.del(generateKey(keyObj)),
+    clear: () => lru.reset(),
     keys: () => lru.keys(),
     getInitialState: () =>
       lru.keys().reduce(

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -1,12 +1,12 @@
-import LRU from 'tiny-lru'
 import fnv1a from '@sindresorhus/fnv1a'
+import QuickLRU from 'quick-lru'
 
 function generateKey(keyObj) {
   return fnv1a(JSON.stringify(keyObj)).toString(36)
 }
 
-export default function memCache({ size = 100, ttl = 0, initialState } = {}) {
-  const lru = LRU(size, ttl)
+export default function memCache({ size = 100, initialState } = {}) {
+  const lru = new QuickLRU({ maxSize: size })
 
   if (initialState) {
     Object.keys(initialState).map(k => {

--- a/packages/graphql-hooks/.size-snapshot.json
+++ b/packages/graphql-hooks/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "lib/graphql-hooks.js": {
-    "bundled": 11781,
-    "minified": 5768,
-    "gzipped": 1968
+    "bundled": 15350,
+    "minified": 7386,
+    "gzipped": 2505
   },
   "es/graphql-hooks.js": {
-    "bundled": 11436,
-    "minified": 5476,
-    "gzipped": 1896,
+    "bundled": 14973,
+    "minified": 7068,
+    "gzipped": 2420,
     "treeshaked": {
       "rollup": {
-        "code": 67,
-        "import_statements": 21
+        "code": 104,
+        "import_statements": 58
       },
       "webpack": {
-        "code": 1069
+        "code": 1172
       }
     }
   },
   "es/graphql-hooks.mjs": {
-    "bundled": 4091,
-    "minified": 4091,
-    "gzipped": 1566,
+    "bundled": 6226,
+    "minified": 6223,
+    "gzipped": 2436,
     "treeshaked": {
       "rollup": {
         "code": 67,
@@ -33,14 +33,14 @@
     }
   },
   "dist/graphql-hooks.js": {
-    "bundled": 12028,
-    "minified": 5268,
-    "gzipped": 1975
+    "bundled": 17632,
+    "minified": 7791,
+    "gzipped": 2880
   },
   "dist/graphql-hooks.min.js": {
-    "bundled": 5224,
-    "minified": 5224,
-    "gzipped": 1948
+    "bundled": 7717,
+    "minified": 7703,
+    "gzipped": 2845
   },
   "lib\\graphql-hooks.js": {
     "bundled": 12621,


### PR DESCRIPTION
### What does this PR do?

tiny-lru caused import error, even on a very basic example (cf nextjs/examples repo). 

Swapping tiny-lru by another lru package does the trick. 
tiny-lru does not seem very suitable for es6 import: 
- https://github.com/avoidwork/tiny-lru#example  
- https://github.com/avoidwork/tiny-lru/issues/19

### Related issues

https://github.com/nearform/graphql-hooks/issues/366

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
