### PR TITLE
fix #366 - fix the import issues for webpack

### DIFF
--- a/packages/graphql-hooks-memcache/.size-snapshot.json
+++ b/packages/graphql-hooks-memcache/.size-snapshot.json
@@ -1,46 +1,46 @@
 {
   "lib/graphql-hooks-memcache.js": {
-    "bundled": 953,
-    "minified": 638,
-    "gzipped": 377
+    "bundled": 936,
+    "minified": 621,
+    "gzipped": 369
   },
   "es/graphql-hooks-memcache.js": {
-    "bundled": 780,
-    "minified": 507,
-    "gzipped": 320,
+    "bundled": 763,
+    "minified": 490,
+    "gzipped": 311,
     "treeshaked": {
       "rollup": {
-        "code": 62,
-        "import_statements": 62
+        "code": 45,
+        "import_statements": 45
       },
       "webpack": {
-        "code": 1079
+        "code": 1062
       }
     }
   },
   "es/graphql-hooks-memcache.mjs": {
-    "bundled": 2808,
-    "minified": 2795,
-    "gzipped": 1094,
+    "bundled": 1880,
+    "minified": 1880,
+    "gzipped": 814,
     "treeshaked": {
       "rollup": {
-        "code": 2254,
+        "code": 0,
         "import_statements": 0
       },
       "webpack": {
-        "code": 3365
+        "code": 1099
       }
     }
   },
   "dist/graphql-hooks-memcache.js": {
-    "bundled": 5999,
-    "minified": 3015,
-    "gzipped": 1196
+    "bundled": 3964,
+    "minified": 2087,
+    "gzipped": 926
   },
   "dist/graphql-hooks-memcache.min.js": {
-    "bundled": 3007,
-    "minified": 2994,
-    "gzipped": 1188
+    "bundled": 2079,
+    "minified": 2079,
+    "gzipped": 922
   },
   "lib\\graphql-hooks-memcache.js": {
     "bundled": 936,

--- a/packages/graphql-hooks-memcache/.size-snapshot.json
+++ b/packages/graphql-hooks-memcache/.size-snapshot.json
@@ -1,46 +1,46 @@
 {
   "lib/graphql-hooks-memcache.js": {
-    "bundled": 936,
-    "minified": 621,
-    "gzipped": 369
+    "bundled": 953,
+    "minified": 638,
+    "gzipped": 377
   },
   "es/graphql-hooks-memcache.js": {
-    "bundled": 763,
-    "minified": 490,
-    "gzipped": 311,
+    "bundled": 780,
+    "minified": 507,
+    "gzipped": 320,
     "treeshaked": {
       "rollup": {
-        "code": 45,
-        "import_statements": 45
+        "code": 62,
+        "import_statements": 62
       },
       "webpack": {
-        "code": 1062
+        "code": 1079
       }
     }
   },
   "es/graphql-hooks-memcache.mjs": {
-    "bundled": 2080,
-    "minified": 2076,
-    "gzipped": 886,
+    "bundled": 2808,
+    "minified": 2795,
+    "gzipped": 1094,
     "treeshaked": {
       "rollup": {
-        "code": 1471,
+        "code": 2254,
         "import_statements": 0
       },
       "webpack": {
-        "code": 2521
+        "code": 3365
       }
     }
   },
   "dist/graphql-hooks-memcache.js": {
-    "bundled": 4451,
-    "minified": 2281,
-    "gzipped": 973
+    "bundled": 5999,
+    "minified": 3015,
+    "gzipped": 1196
   },
   "dist/graphql-hooks-memcache.min.js": {
-    "bundled": 2277,
-    "minified": 2263,
-    "gzipped": 969
+    "bundled": 3007,
+    "minified": 2994,
+    "gzipped": 1188
   },
   "lib\\graphql-hooks-memcache.js": {
     "bundled": 936,

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sindresorhus/fnv1a": "^1.2.0",
-    "tiny-lru": "^6.0.1"
+    "tiny-lru": "^7.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -1,4 +1,4 @@
-import LRU from 'tiny-lru'
+import LRU from 'tiny-lru/lib/tiny-lru.es5'
 import fnv1a from '@sindresorhus/fnv1a'
 
 function generateKey(keyObj) {

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -1,4 +1,4 @@
-import LRU from 'tiny-lru/lib/tiny-lru.es5'
+import LRU from 'tiny-lru'
 import fnv1a from '@sindresorhus/fnv1a'
 
 function generateKey(keyObj) {

--- a/packages/graphql-hooks/.size-snapshot.json
+++ b/packages/graphql-hooks/.size-snapshot.json
@@ -1,46 +1,46 @@
 {
   "lib/graphql-hooks.js": {
-    "bundled": 11781,
-    "minified": 5768,
-    "gzipped": 1968
+    "bundled": 15350,
+    "minified": 7386,
+    "gzipped": 2505
   },
   "es/graphql-hooks.js": {
-    "bundled": 11436,
-    "minified": 5476,
-    "gzipped": 1896,
+    "bundled": 14973,
+    "minified": 7068,
+    "gzipped": 2420,
     "treeshaked": {
       "rollup": {
-        "code": 67,
-        "import_statements": 21
+        "code": 104,
+        "import_statements": 58
       },
       "webpack": {
-        "code": 1069
+        "code": 1172
       }
     }
   },
   "es/graphql-hooks.mjs": {
-    "bundled": 4091,
-    "minified": 4091,
-    "gzipped": 1566,
+    "bundled": 6226,
+    "minified": 6223,
+    "gzipped": 2436,
     "treeshaked": {
       "rollup": {
         "code": 67,
         "import_statements": 21
       },
       "webpack": {
-        "code": 1071
+        "code": 1151
       }
     }
   },
   "dist/graphql-hooks.js": {
-    "bundled": 12028,
-    "minified": 5268,
-    "gzipped": 1975
+    "bundled": 17632,
+    "minified": 7791,
+    "gzipped": 2880
   },
   "dist/graphql-hooks.min.js": {
-    "bundled": 5224,
-    "minified": 5224,
-    "gzipped": 1948
+    "bundled": 7717,
+    "minified": 7703,
+    "gzipped": 2845
   },
   "lib\\graphql-hooks.js": {
     "bundled": 12621,


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of what this pull request is for, please provide any background -->

Tries to fix webpack import issue when used within next.js applications.
Compared to #369, this PR attempts to keep the current LRU package.

This PR changes the import for tiny-lru to use ES5 code from tiny-lru, because tiny-lru does not expose es6 correctly.

Note: I plan to fix the tiny-lru es6 export issue, at which point we should upgrade this import to use es6 instead.

### Related issues

<!-- Link to any related issues here -->
#366 
#369 (PR)

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
