### PR TITLE
fix: disable acceptance-tests ciricleci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,31 +37,31 @@ jobs:
           path: reports/junit
 
       - run: npm run coveralls
-  acceptance-tests:
-    working_directory: ~/graphql-hooks
-    environment:
-      BROWSERSTACK_PARALLEL_RUNS: '5'
-      BROWSERSTACK_USE_AUTOMATE: '1'
-      BROWSERSTACK_PROJECT_NAME: 'graphql-hooks'
-    docker:
-      - image: circleci/node:10.15
-    steps:
-      - checkout
+  # acceptance-tests:
+  #   working_directory: ~/graphql-hooks
+  #   environment:
+  #     BROWSERSTACK_PARALLEL_RUNS: '5'
+  #     BROWSERSTACK_USE_AUTOMATE: '1'
+  #     BROWSERSTACK_PROJECT_NAME: 'graphql-hooks'
+  #   docker:
+  #     - image: circleci/node:10.15
+  #   steps:
+  #     - checkout
 
-      - restore_cache:
-          key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
+  #     - restore_cache:
+  #         key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
 
-      - run: npm install
+  #     - run: npm install
 
-      - save_cache:
-          key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
-          paths:
-            - ~/graphql-hooks/node_modules
-            - ~/graphql-hooks/packages/graphql-hooks/node_modules
-            - ~/graphql-hooks/packages/graphql-hooks-memcache/node_modules
-            - ~/graphql-hooks/packages/graphql-hooks-ssr/node_modules
+  #     - save_cache:
+  #         key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
+  #         paths:
+  #           - ~/graphql-hooks/node_modules
+  #           - ~/graphql-hooks/packages/graphql-hooks/node_modules
+  #           - ~/graphql-hooks/packages/graphql-hooks-memcache/node_modules
+  #           - ~/graphql-hooks/packages/graphql-hooks-ssr/node_modules
 
-      - run: npm run test:acceptance:ci
+  #     - run: npm run test:acceptance:ci
 
-      - store_test_results:
-          path: /tmp/acceptance-test-results
+  #     - store_test_results:
+  #         path: /tmp/acceptance-test-results

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "eslint": "eslint '**/*.js'",
     "prettier": "prettier '**/*.js' '**/*.md' '**/*.ts' --write",
-    "release": "lerna publish"
+    "release": "lerna publish",
+    "clean": "lerna clean"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.5",


### PR DESCRIPTION
### What does this PR do?
Disables `acceptance-tests` circleci job, it's been a frequent source of failing builds ❌mainly due to browserstack failing when running more than 5 parallel tests, we need to cough up 💸 to get more.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
