### PR TITLE
fix: re-enable acceptance tests, remove browserstack usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
     working_directory: ~/graphql-hooks
     environment:
     docker:
-      - image: circleci/node:10.15
+      - image: circleci/node:10.15-browsers
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,31 +37,28 @@ jobs:
           path: reports/junit
 
       - run: npm run coveralls
-  # acceptance-tests:
-  #   working_directory: ~/graphql-hooks
-  #   environment:
-  #     BROWSERSTACK_PARALLEL_RUNS: '5'
-  #     BROWSERSTACK_USE_AUTOMATE: '1'
-  #     BROWSERSTACK_PROJECT_NAME: 'graphql-hooks'
-  #   docker:
-  #     - image: circleci/node:10.15
-  #   steps:
-  #     - checkout
+  acceptance-tests:
+    working_directory: ~/graphql-hooks
+    environment:
+    docker:
+      - image: circleci/node:10.15
+    steps:
+      - checkout
 
-  #     - restore_cache:
-  #         key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
+      - restore_cache:
+          key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
 
-  #     - run: npm install
+      - run: npm install
 
-  #     - save_cache:
-  #         key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
-  #         paths:
-  #           - ~/graphql-hooks/node_modules
-  #           - ~/graphql-hooks/packages/graphql-hooks/node_modules
-  #           - ~/graphql-hooks/packages/graphql-hooks-memcache/node_modules
-  #           - ~/graphql-hooks/packages/graphql-hooks-ssr/node_modules
+      - save_cache:
+          key: graphql-hooks-key-{{ checksum "~/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-memcache/package.json" }}-{{ checksum "~/graphql-hooks/packages/graphql-hooks-ssr/package.json" }}
+          paths:
+            - ~/graphql-hooks/node_modules
+            - ~/graphql-hooks/packages/graphql-hooks/node_modules
+            - ~/graphql-hooks/packages/graphql-hooks-memcache/node_modules
+            - ~/graphql-hooks/packages/graphql-hooks-ssr/node_modules
 
-  #     - run: npm run test:acceptance:ci
+      - run: npm run test:acceptance
 
-  #     - store_test_results:
-  #         path: /tmp/acceptance-test-results
+      - store_test_results:
+          path: /tmp/acceptance-test-results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,6 @@ We don't use async/await in this library due to transpilation costs. Instead we 
 
 We use [testcafe](https://github.com/DevExpress/testcafe) to run acceptance tests against our [create-react-app example](examples/create-react-app) application. This is to ensure that the bundled versions of the code work as they should in an application.
 You can run these locally on Chrome by running `npm run test:acceptance`. You should make sure that the packages have been built and the create-react-app example is running on port 3000 locally.
-When you open a pull request CircleCI will run the tests using [Browserstack](https://browserstack.com) on Chrome, Firefox, Safari and IE 11.
 
 ## For Collaborators
 

--- a/README.md
+++ b/README.md
@@ -754,7 +754,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
-
-[![BrowserStack](https://p14.zdusercontent.com/attachment/1015988/mg687dwxHqXtriITEf8kxZV3W?token=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..tPLabhhdTeWxyc3TTt-RCg.bmk4nO95zIaYIcNaaDEVtxph9ap6d9X__07O0wPpvgsx5RBYvue1gMxCGhnYcgtQA51YjC5BFCxev9bBGZ0f6wHGr83j_nBID68oZCdgurHQhuZjsBZTotXtVdGDJoGg8KHMvl2qK9_FFlxohxGkPatEyccPXfLxZGGrGhvGnZVs6sFcy5bSevRHwe84yH3y0-PhbwE9HPAqzYsJyjBsSnez3gllgrIqX_7UucPPyAxtESSOaevl3zs6n5EfJ6teaJ3_KhWTmux9Nlk5csiWwvcRcCXp7p14Xln9tBYR64k.-1SqygSW1Ke0iJ-t3ED3SQ)](http://browserstack.com/)
-
-We use BrowserStack to support as many browsers and devices as possible

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:acceptance": "testcafe chrome test/acceptance/",
-    "test:acceptance:ci": "testcafe browserstack:chrome,browserstack:firefox,browserstack:ie,browserstack:safari test/acceptance/ -r xunit:/tmp/acceptance-test-results/res.xml",
     "postinstall": "lerna bootstrap --no-ci && lerna run build",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "eslint": "eslint '**/*.js'",
@@ -37,7 +36,6 @@
     "rollup-plugin-size-snapshot": "^0.10.0",
     "rollup-plugin-terser": "^5.0.0",
     "testcafe": "^1.2.1",
-    "testcafe-browser-provider-browserstack": "^1.8.0",
     "testcafe-reporter-xunit": "^2.1.0"
   },
   "lint-staged": {


### PR DESCRIPTION
### What does this PR do?
- Removes browserstack from the acceptance tests, it's been source of pain for a while for failed builds.
- Re-enables the acceptance tests, which will run the tests on testcafe 

### Related issues
N/A

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
