### PR TITLE
Fix caching issue when options.updateData is passed

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -22,7 +22,7 @@ function reducer(state, action) {
         loading: true
       }
     case actionTypes.CACHE_HIT:
-      if (state.cacheHit) {
+      if (state.cacheHit && !action.resetState) {
         // we can be sure this is the same cacheKey hit
         // because we dispatch RESET_STATE if it changes
         return state
@@ -139,7 +139,8 @@ function useClientRequest(query, initialOpts = {}) {
       if (cacheHit) {
         dispatch({
           type: actionTypes.CACHE_HIT,
-          result: cacheHit
+          result: cacheHit,
+          resetState: stringifiedCacheKey !== JSON.stringify(state.cacheKey)
         })
 
         return Promise.resolve(cacheHit)

--- a/packages/graphql-hooks/test/integration/useQuery.test.js
+++ b/packages/graphql-hooks/test/integration/useQuery.test.js
@@ -115,16 +115,23 @@ describe('useQuery Integrations', () => {
   })
 
   it('should not rerender after a SSR', () => {
+    const query = 'query { hiya }'
     client = new GraphQLClient({
       url: '/graphql',
       cache: {
-        get: () => ({ error: false, data: 'hello' })
+        get: () => ({
+          error: false,
+          data: 'hello',
+          cacheKey: client.getCacheKey({
+            query
+          })
+        })
       }
     })
 
     wrapper = getWrapper(client)
 
-    const { getByTestId } = render(<TestComponent />, {
+    const { getByTestId } = render(<TestComponent query={query} />, {
       wrapper
     })
 


### PR DESCRIPTION
### What does this PR do?

Updates the dispatch call for `CACHE_HIT` which sets `resetState: boolean` if the state.cacheKey is different from the current cacheKey.

### Related issues

#387 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
