### PR TITLE
Use generics in GraphQLClient.request method

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -29,7 +29,8 @@ export class GraphQLClient {
     options: UseClientRequestOptions<Variables>
   ): CacheKeyObject
   getFetchOptions(operation: Operation, fetchOptionsOverrides?: object): object
-  request(operation: Operation, options: object): Promise<Result>
+  request<ResponseData>(operation: Operation, options: object):
+    Promise<Result<ResponseData>>
 }
 
 export function useClientRequest<ResponseData = any, Variables = object>(
@@ -102,8 +103,8 @@ interface APIError {
   graphQLErrors?: object[]
 }
 
-interface Result {
-  data?: object
+interface Result<ResponseData = any> {
+  data?: ResponseData
   error?: APIError
 }
 


### PR DESCRIPTION
### What does this PR do?

It is a small change, but without it, I would always need to cast the data to any:

```
  const result = await client.request({query: QUERY}, {});

  (result.data as any).data.something
```

If this merged, we can simply do this:

```
  const result = await client.request<{data: DataInterface}>({query: QUERY}, {});

  result.data.data.something
```

By the way, I don't think the default type of `Result.data` should be`object` type. More appropriate type is `any` or even `unknown`. Although I think `any` is better.

### Checklist

- [ X ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ X ] I have added or updated any relevant documentation: Not Applicable
- [ X ] I have added or updated any relevant tests: Not Applicable
