### PR TITLE
fix: SSR infinite loop when skipCache=true

### DIFF
--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -13,7 +13,12 @@ function useQuery(query, opts = {}) {
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false)
   const [queryReq, state] = useClientRequest(query, allOpts)
 
-  if (client.ssrMode && opts.ssr !== false && !calledDuringSSR) {
+  if (
+    client.ssrMode &&
+    opts.ssr !== false &&
+    !calledDuringSSR &&
+    !opts.skipCache
+  ) {
     // result may already be in the cache from previous SSR iterations
     if (!state.data && !state.error) {
       const p = queryReq()

--- a/packages/graphql-hooks/test/integration/useQuery.test.js
+++ b/packages/graphql-hooks/test/integration/useQuery.test.js
@@ -285,4 +285,46 @@ describe('Server side rendering', () => {
     const expected = mockCache.getInitialState()
     expect(actual).toEqual(expected)
   })
+
+  it('should skip queries when skipCache=true', async () => {
+    const mockQuery = 'query { stuff }'
+    const fetchMock = jest.fn().mockResolvedValue({
+      data: {
+        users: [
+          {
+            name: 'Brian'
+          }
+        ]
+      }
+    })
+
+    const client = new GraphQLClient({
+      url: '/graphql',
+      logErrors: true,
+      cache: memCache(),
+      fetch: fetchMock
+    })
+
+    const Component = () => {
+      // we just need to call the hook
+      useQuery(mockQuery, { skipCache: true })
+      return <div>hello</div>
+    }
+
+    const App = (
+      <ClientContext.Provider value={client}>
+        <Component />
+      </ClientContext.Provider>
+    )
+
+    const actual = await getInitialState({
+      App,
+      client
+    })
+
+    const expected = {}
+
+    expect(actual).toEqual(expected)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Adds a check before calling the `queryReq` fn during SSR, if the `skipCache` option is `false`, we ignore.

### Related issues

#396 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
