### PR TITLE
Fix onerror not called

### DIFF
--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -50,38 +50,47 @@ class GraphQLClient {
   }
   /* eslint-disable no-console */
   logErrorResult({ result, operation }) {
-    if (this.onError) {
-      return this.onError({ result, operation })
-    }
+    if (this.logErrors) {
+      console.error('GraphQL Hooks Error')
+      console.groupCollapsed('---> Full Error Details')
+      console.groupCollapsed('Operation:')
+      console.log(operation)
+      console.groupEnd()
 
-    console.error('GraphQL Hooks Error')
-    console.groupCollapsed('---> Full Error Details')
-    console.groupCollapsed('Operation:')
-    console.log(operation)
-    console.groupEnd()
+      const error = result.error
 
-    const error = result.error
+      if (!error) {
+        return
+      }
 
-    if (error.fetchError) {
-      console.groupCollapsed('FETCH ERROR:')
-      console.log(error.fetchError)
+      if (error.fetchError) {
+        console.groupCollapsed('FETCH ERROR:')
+        console.log(error.fetchError)
+        console.groupEnd()
+      }
+
+      if (error.httpError) {
+        console.groupCollapsed('HTTP ERROR:')
+        console.log(error.httpError)
+        console.groupEnd()
+      }
+
+      if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+        console.groupCollapsed('GRAPHQL ERROR:')
+        error.graphQLErrors.forEach(err => console.log(err))
+        console.groupEnd()
+      }
+
       console.groupEnd()
     }
-
-    if (error.httpError) {
-      console.groupCollapsed('HTTP ERROR:')
-      console.log(error.httpError)
-      console.groupEnd()
-    }
-
-    if (error.graphQLErrors && error.graphQLErrors.length > 0) {
-      console.groupCollapsed('GRAPHQL ERROR:')
-      error.graphQLErrors.forEach(err => console.log(err))
-      console.groupEnd()
-    }
-
-    console.groupEnd()
   }
+
+  notifyErrorResult({ result, operation }) {
+    if (this.onError) {
+      this.onError({ result, operation })
+    }
+  }
+
   /* eslint-enable no-console */
   generateResult({ fetchError, httpError, graphQLErrors, data }) {
     const errorFound = !!(
@@ -219,8 +228,9 @@ class GraphQLClient {
         })
       })
       .then(result => {
-        if (result.error && this.logErrors) {
+        if (result.error) {
           this.logErrorResult({ result, operation })
+          this.notifyErrorResult({ result, operation })
         }
         return result
       })

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -58,26 +58,24 @@ class GraphQLClient {
 
     const error = result.error
 
-    if (!error) {
-      return
-    }
+    if (error) {
+      if (error.fetchError) {
+        console.groupCollapsed('FETCH ERROR:')
+        console.log(error.fetchError)
+        console.groupEnd()
+      }
 
-    if (error.fetchError) {
-      console.groupCollapsed('FETCH ERROR:')
-      console.log(error.fetchError)
-      console.groupEnd()
-    }
+      if (error.httpError) {
+        console.groupCollapsed('HTTP ERROR:')
+        console.log(error.httpError)
+        console.groupEnd()
+      }
 
-    if (error.httpError) {
-      console.groupCollapsed('HTTP ERROR:')
-      console.log(error.httpError)
-      console.groupEnd()
-    }
-
-    if (error.graphQLErrors && error.graphQLErrors.length > 0) {
-      console.groupCollapsed('GRAPHQL ERROR:')
-      error.graphQLErrors.forEach(err => console.log(err))
-      console.groupEnd()
+      if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+        console.groupCollapsed('GRAPHQL ERROR:')
+        error.graphQLErrors.forEach(err => console.log(err))
+        console.groupEnd()
+      }
     }
 
     console.groupEnd()

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -50,48 +50,40 @@ class GraphQLClient {
   }
   /* eslint-disable no-console */
   logErrorResult({ result, operation }) {
-    if (this.logErrors) {
-      console.error('GraphQL Hooks Error')
-      console.groupCollapsed('---> Full Error Details')
-      console.groupCollapsed('Operation:')
-      console.log(operation)
-      console.groupEnd()
+    console.error('GraphQL Hooks Error')
+    console.groupCollapsed('---> Full Error Details')
+    console.groupCollapsed('Operation:')
+    console.log(operation)
+    console.groupEnd()
 
-      const error = result.error
+    const error = result.error
 
-      if (!error) {
-        return
-      }
+    if (!error) {
+      return
+    }
 
-      if (error.fetchError) {
-        console.groupCollapsed('FETCH ERROR:')
-        console.log(error.fetchError)
-        console.groupEnd()
-      }
-
-      if (error.httpError) {
-        console.groupCollapsed('HTTP ERROR:')
-        console.log(error.httpError)
-        console.groupEnd()
-      }
-
-      if (error.graphQLErrors && error.graphQLErrors.length > 0) {
-        console.groupCollapsed('GRAPHQL ERROR:')
-        error.graphQLErrors.forEach(err => console.log(err))
-        console.groupEnd()
-      }
-
+    if (error.fetchError) {
+      console.groupCollapsed('FETCH ERROR:')
+      console.log(error.fetchError)
       console.groupEnd()
     }
-  }
 
-  notifyErrorResult({ result, operation }) {
-    if (this.onError) {
-      this.onError({ result, operation })
+    if (error.httpError) {
+      console.groupCollapsed('HTTP ERROR:')
+      console.log(error.httpError)
+      console.groupEnd()
     }
-  }
 
+    if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+      console.groupCollapsed('GRAPHQL ERROR:')
+      error.graphQLErrors.forEach(err => console.log(err))
+      console.groupEnd()
+    }
+
+    console.groupEnd()
+  }
   /* eslint-enable no-console */
+
   generateResult({ fetchError, httpError, graphQLErrors, data }) {
     const errorFound = !!(
       (graphQLErrors && graphQLErrors.length > 0) ||
@@ -229,8 +221,13 @@ class GraphQLClient {
       })
       .then(result => {
         if (result.error) {
-          this.logErrorResult({ result, operation })
-          this.notifyErrorResult({ result, operation })
+          if (this.logErrors) {
+            this.logErrorResult({ result, operation })
+          }
+
+          if (this.onError) {
+            this.onError({ result, operation })
+          }
         }
         return result
       })

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -152,8 +152,9 @@ describe('GraphQLClient', () => {
       const client = new GraphQLClient({ ...validConfig })
 
       client.logErrorResult({ result: 'result', operation: 'operation' })
+      expect(groupCollapsedSpy).toHaveBeenCalledTimes(2)
       expect(errorLogSpy).toHaveBeenCalledWith('GraphQL Hooks Error')
-      expect(groupEndSpy).toHaveBeenCalled()
+      expect(groupEndSpy).toHaveBeenCalledTimes(2)
     })
 
     it('logs a fetchError', () => {
@@ -163,18 +164,20 @@ describe('GraphQLClient', () => {
         result: { error: { fetchError: 'on no fetch!' } }
       })
       expect(errorLogSpy).toHaveBeenCalledWith('GraphQL Hooks Error')
+      expect(groupCollapsedSpy).toHaveBeenCalledTimes(3)
       expect(groupCollapsedSpy).toHaveBeenCalledWith('FETCH ERROR:')
       expect(logSpy).toHaveBeenCalledWith('on no fetch!')
-      expect(groupEndSpy).toHaveBeenCalled()
+      expect(groupEndSpy).toHaveBeenCalledTimes(3)
     })
 
     it('logs an httpError', () => {
       const client = new GraphQLClient({ ...validConfig })
       client.logErrorResult({ result: { error: { httpError: 'on no http!' } } })
       expect(errorLogSpy).toHaveBeenCalledWith('GraphQL Hooks Error')
+      expect(groupCollapsedSpy).toHaveBeenCalledTimes(3)
       expect(groupCollapsedSpy).toHaveBeenCalledWith('HTTP ERROR:')
       expect(logSpy).toHaveBeenCalledWith('on no http!')
-      expect(groupEndSpy).toHaveBeenCalled()
+      expect(groupEndSpy).toHaveBeenCalledTimes(3)
     })
 
     it('logs all graphQLErrors', () => {
@@ -182,10 +185,11 @@ describe('GraphQLClient', () => {
       const graphQLErrors = ['on no GraphQL!', 'oops GraphQL!']
       client.logErrorResult({ result: { error: { graphQLErrors } } })
       expect(errorLogSpy).toHaveBeenCalledWith('GraphQL Hooks Error')
+      expect(groupCollapsedSpy).toHaveBeenCalledTimes(3)
       expect(groupCollapsedSpy).toHaveBeenCalledWith('GRAPHQL ERROR:')
       expect(logSpy).toHaveBeenCalledWith('on no GraphQL!')
       expect(logSpy).toHaveBeenCalledWith('oops GraphQL!')
-      expect(groupEndSpy).toHaveBeenCalled()
+      expect(groupEndSpy).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -148,14 +148,23 @@ describe('GraphQLClient', () => {
       jest.restoreAllMocks()
     })
 
-    it('calls onError if present', () => {
-      const onError = jest.fn()
-      const client = new GraphQLClient({ ...validConfig, onError })
+    it('skip logging errors', () => {
+      const client = new GraphQLClient({ ...validConfig })
+      client.logErrors = false
+
       client.logErrorResult({ result: 'result', operation: 'operation' })
-      expect(onError).toHaveBeenCalledWith({
-        result: 'result',
-        operation: 'operation'
-      })
+      expect(errorLogSpy).not.toHaveBeenCalled()
+      expect(groupEndSpy).not.toHaveBeenCalled()
+      expect(logSpy).not.toHaveBeenCalled()
+      expect(groupEndSpy).not.toHaveBeenCalled()
+    })
+
+    it('logs without error', () => {
+      const client = new GraphQLClient({ ...validConfig })
+
+      client.logErrorResult({ result: 'result', operation: 'operation' })
+      expect(errorLogSpy).toHaveBeenCalledWith('GraphQL Hooks Error')
+      expect(groupEndSpy).toHaveBeenCalled()
     })
 
     it('logs a fetchError', () => {
@@ -188,6 +197,22 @@ describe('GraphQLClient', () => {
       expect(logSpy).toHaveBeenCalledWith('on no GraphQL!')
       expect(logSpy).toHaveBeenCalledWith('oops GraphQL!')
       expect(groupEndSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('notifyErrorResult', () => {
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('calls onError if present', () => {
+      const onError = jest.fn()
+      const client = new GraphQLClient({ ...validConfig, onError })
+      client.notifyErrorResult({ result: 'result', operation: 'operation' })
+      expect(onError).toHaveBeenCalledWith({
+        result: 'result',
+        operation: 'operation'
+      })
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of what this pull request is for, please provide any background -->

This PR decouples `onError` custom error handler from `logErrors` flag to allow the use of a custom handler without the need to set `logErrors` flag to `true`.
This align the actual behaviour of the 2 options to what is documented in the `README`.

### Related issues

#337 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
