### PR TITLE
fix: Transpile to ES5 for support in IE/Edge

### DIFF
--- a/packages/graphql-hooks-memcache/src/.babelrc.js
+++ b/packages/graphql-hooks-memcache/src/.babelrc.js
@@ -1,0 +1,21 @@
+const { NODE_ENV } = process.env
+
+module.exports = {
+  presets: [
+    [
+      '@babel/env',
+      {
+        targets: {
+          browsers: ['ie >= 11']
+        },
+        modules: false,
+        loose: true
+      }
+    ]
+  ],
+  plugins: [
+    // don't use `loose` mode here - need to copy symbols when spreading
+    '@babel/proposal-object-rest-spread',
+    NODE_ENV === 'test' && '@babel/transform-modules-commonjs'
+  ].filter(Boolean)
+}


### PR DESCRIPTION
### What does this PR do?

Fixes errors in IE and Edge for `graphql-hooks-memcache` by transpiling to ES5.

I copied the `.babelrc.js` from `graphql-hooks/src/` into the root directory of `graphql-hooks-memcache`. I think it's better to be in root but I can put in `src` if that's what you would prefer.

### Related issues

 #331

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
