### PR TITLE
fix: graphql-hooks-memcache IE11 support

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -12,13 +12,14 @@ const pkg = require(`${packageDir}/package.json`)
 const external = [...Object.keys(pkg.peerDependencies || {})]
 
 // name will be used as the global name exposed in the UMD bundles
-const generateRollupConfig = name => [
+const generateRollupConfig = (name, overrides = {}) => [
   // CommonJS
   {
     input: 'src/index.js',
     output: { file: `lib/${pkg.name}.js`, format: 'cjs', indent: false },
     external,
-    plugins: [babel(), sizeSnapshot()]
+    plugins: [babel(), sizeSnapshot()],
+    ...overrides
   },
 
   // ES
@@ -26,7 +27,8 @@ const generateRollupConfig = name => [
     input: 'src/index.js',
     output: { file: `es/${pkg.name}.js`, format: 'es', indent: false },
     external,
-    plugins: [babel(), sizeSnapshot()]
+    plugins: [babel(), sizeSnapshot()],
+    ...overrides
   },
 
   // ES for Browsers
@@ -51,7 +53,8 @@ const generateRollupConfig = name => [
         }
       }),
       sizeSnapshot()
-    ]
+    ],
+    ...overrides
   },
 
   // UMD Development
@@ -76,7 +79,8 @@ const generateRollupConfig = name => [
         'process.env.NODE_ENV': JSON.stringify('development')
       }),
       sizeSnapshot()
-    ]
+    ],
+    ...overrides
   },
 
   // UMD Production
@@ -109,7 +113,8 @@ const generateRollupConfig = name => [
         }
       }),
       sizeSnapshot()
-    ]
+    ],
+    ...overrides
   }
 ]
 

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -18,9 +18,6 @@
     "eject": "react-scripts eject"
   },
   "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
+    "ie >= 11"
   ]
 }

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -1,17 +1,24 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { GraphQLClient, ClientContext } from 'graphql-hooks'
-
+import memCache from 'graphql-hooks-memcache'
 import Posts from './components/Posts'
 
 const client = new GraphQLClient({
+  cache: memCache(),
   url: 'https://api.graph.cool/simple/v1/cjs4qo29b2w0c0130tfx6maca'
 })
 
 export default function App() {
+  const [showPosts, setShowPosts] = useState(true)
+
+  const togglePosts = () => setShowPosts(!showPosts)
+
   return (
     <ClientContext.Provider value={client}>
       <h1>Postie</h1>
-      <Posts />
+      <span>Verify caching by hiding/showing the posts: </span>
+      <button onClick={togglePosts}>{showPosts ? 'hide' : 'show'}</button>
+      {showPosts && <Posts />}
     </ClientContext.Provider>
   )
 }

--- a/packages/graphql-hooks-memcache/rollup.config.js
+++ b/packages/graphql-hooks-memcache/rollup.config.js
@@ -1,3 +1,10 @@
 import generateRollupConfig from '../../config/rollup.config'
 
-export default generateRollupConfig('GraphQLHooksMemcache')
+const pkg = require('./package.json')
+const externalPeerDeps = [...Object.keys(pkg.peerDependencies || {})]
+
+const overrides = {
+  external: [...externalPeerDeps, '@sindresorhus/fnv1a', 'tiny-lru']
+}
+
+export default generateRollupConfig('GraphQLHooksMemcache', overrides)

--- a/packages/graphql-hooks-memcache/src/.babelrc.js
+++ b/packages/graphql-hooks-memcache/src/.babelrc.js
@@ -1,0 +1,21 @@
+const { NODE_ENV } = process.env
+
+module.exports = {
+  presets: [
+    [
+      '@babel/env',
+      {
+        targets: {
+          browsers: ['ie >= 11']
+        },
+        modules: false,
+        loose: true
+      }
+    ]
+  ],
+  plugins: [
+    // don't use `loose` mode here - need to copy symbols when spreading
+    '@babel/proposal-object-rest-spread',
+    NODE_ENV === 'test' && '@babel/transform-modules-commonjs'
+  ].filter(Boolean)
+}


### PR DESCRIPTION
### What does this PR do?

- Copies the babel config for rollup, same as `graphql-hooks`
- Adds a overrides parameter to the rollup config generator
- Add custom `externals` array for `graphql-hooks-memcache`
- Updated the `create-react-app` to run on IE11 + added memcache

Verified the CRA example via the following steps:

1. In the root of the repo run: `lerna run build`
1. `cd examples/create-react-app`
1. `npm run build`
1. `serve -s build`
1. Verify `localhost:5000` on browserstack (IE11 and Edge)

### Related issues

#331 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
