### PR TITLE
Make TGraphQLError default to "object"

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -19,7 +19,7 @@ export class GraphQLClient {
   setHeader(key: string, value: string): GraphQLClient
   setHeaders(headers: Headers): GraphQLClient
   removeHeader(key: string): GraphQLClient
-  logErrorResult<ResponseData, TGraphQLError>({
+  logErrorResult<ResponseData, TGraphQLError = object>({
     result,
     operation
   }: {
@@ -31,7 +31,7 @@ export class GraphQLClient {
     options: UseClientRequestOptions<Variables>
   ): CacheKeyObject
   getFetchOptions(operation: Operation, fetchOptionsOverrides?: object): object
-  request<ResponseData, TGraphQLError>(
+  request<ResponseData, TGraphQLError = object>(
     operation: Operation,
     options?: object
   ): Promise<Result<ResponseData, TGraphQLError>>
@@ -150,7 +150,7 @@ interface UseQueryOptions<Variables = object>
   ssr?: boolean
 }
 
-interface UseClientRequestResult<ResponseData, TGraphQLError> {
+interface UseClientRequestResult<ResponseData, TGraphQLError = object> {
   loading: boolean
   cacheHit: boolean
   data: ResponseData


### PR DESCRIPTION
### What does this PR do?

This fixes a breaking change introduced in 4.4.0 in #425.

#425 made the type `UseClientRequestResult` (and other functions) require a second type argument: `TGraphQLError`. To avoid a breaking change in a minor release, it should default to `object` if the user don't want to provide a specific `TGraphQLError` type upfront.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests