### PR TITLE
Add useGETForQueries to TS typings for client constructor

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { SubscriptionClient } from 'subscriptions-transport-ws';
 
 // Exports
 
@@ -12,6 +13,8 @@ export class GraphQLClient {
   FormData?: any
   logErrors: boolean
   useGETForQueries: boolean
+
+  subscriptionClient?: SubscriptionClient
 
   private onError(): any
   private fetch(): Promise<any>
@@ -87,7 +90,8 @@ interface ClientOptions {
   cache?: Cache
   headers?: Headers
   ssrMode?: boolean
-  useGETForQueries?: boolean;
+  useGETForQueries?: boolean
+  subscriptionClient?: SubscriptionClient
   fetch?(url: string, options?: object): Promise<object>
   fetchOptions?: object
   FormData?: any

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -87,6 +87,7 @@ interface ClientOptions {
   cache?: Cache
   headers?: Headers
   ssrMode?: boolean
+  useGETForQueries?: boolean;
   fetch?(url: string, options?: object): Promise<object>
   fetchOptions?: object
   FormData?: any

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -47,7 +47,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.12.0",
-    "rollup": "^1.25.2"
+    "rollup": "^1.25.2",
+    "subscriptions-transport-ws": "^0.9.16"
   },
   "repository": {
     "type": "git",

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -247,6 +247,10 @@ class GraphQLClient {
   }
 
   createSubscription(operation) {
+    if (!this.subscriptionClient) {
+      throw new Error('No SubscriptionClient! Please set in the constructor.')
+    }
+
     return this.subscriptionClient.request(operation)
   }
 }


### PR DESCRIPTION
### What does this PR do?

- Fixes missing `useGETForQueries: boolean` in the TS typings for the `GraphQLClient` constructor.
- Fix missing `subscriptionClient` in the `GraphQLClient` constructor.
- Throws an error if trying to use `subscriptionClient` internally in `GraphQLClient` if it's not set.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests