### PR TITLE
Add ability to pass client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages/graphql-hooks/README.md
 packages/*/LICENSE
 build
 .size-snapshot.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ This is a custom hook that takes care of fetching your query and storing the res
   - `updateData(previousData, data)`: Function - Custom handler for merging previous & new query results; return value will replace `data` in `useQuery` return value
     - `previousData`: Previous GraphQL query or `updateData` result
     - `data`: New GraphQL query result
+  - `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
 
 ### `useQuery` return value
 
@@ -339,6 +340,7 @@ The `options` object that can be passed either to `useMutation(mutation, options
 - `variables`: Object e.g. `{ limit: 10 }`
 - `operationName`: If your query has multiple operations, pass the name of the operation you wish to execute.
 - `fetchOptionsOverrides`: Object - Specific overrides for this query. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) for info on what options can be passed
+- `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
 
 ## `useSubscription`
 
@@ -352,6 +354,7 @@ To use subscription you need to use [subscriptions-transport-ws](https://github.
   - `query`: String (required) - the GraphQL query
   - `variables`: Object (optional) - Any variables the query might need
   - `operationName`: String (optional) - If your query has mulitple operations, you can choose which operation you want to call.
+  - `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
 - `callback`: Function - This will be invoked when the subscription recieves an event from your GraphQL server - it will recieve an object with the typical GraphQL response of `{ data: <your result>, errors?: [Error] }`
 
 **Usage**

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -77,7 +77,7 @@ export interface SubscriptionRequest {
 }
 
 export function useSubscription(
-  operation: Operation,
+  operation: UseSubscriptionOperation,
   callback: (response: Result) => void
 ): void
 
@@ -148,6 +148,7 @@ interface UseClientRequestOptions<Variables = object> {
   skipCache?: boolean
   fetchOptionsOverrides?: object
   updateData?(previousData: any, data: any): any
+  client?: GraphQLClient
 }
 
 interface UseQueryOptions<Variables = object>
@@ -170,6 +171,10 @@ interface UseQueryResult<
   refetch(
     options?: UseQueryOptions<Variables>
   ): Promise<UseClientRequestResult<ResponseData, TGraphQLError>>
+}
+
+interface UseSubscriptionOperation extends Operation {
+  client?: GraphqlClient
 }
 
 type FetchData<ResponseData, Variables = object, TGraphQLError = object> = (

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -72,7 +72,8 @@ function useClientRequest(query, initialOpts = {}) {
     )
   }
 
-  const client = React.useContext(ClientContext)
+  const contextClient = React.useContext(ClientContext)
+  const client = initialOpts.client || contextClient
   const isMounted = React.useRef(true)
   const activeCacheKey = React.useRef(null)
   const operation = {

--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -9,7 +9,8 @@ const defaultOpts = {
 
 function useQuery(query, opts = {}) {
   const allOpts = { ...defaultOpts, ...opts }
-  const client = React.useContext(ClientContext)
+  const contextClient = React.useContext(ClientContext)
+  const client = opts.client || contextClient
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false)
   const [queryReq, state] = useClientRequest(query, allOpts)
 

--- a/packages/graphql-hooks/src/useSubscription.js
+++ b/packages/graphql-hooks/src/useSubscription.js
@@ -6,7 +6,8 @@ function useSubscription(options, callback) {
   const callbackRef = useRef(callback)
   callbackRef.current = callback
 
-  const client = useContext(ClientContext)
+  const contextClient = useContext(ClientContext)
+  const client = options.client || contextClient
 
   const request = {
     query: options.query,

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -4,6 +4,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import { useClientRequest, ClientContext } from '../../src'
 
 let mockClient
+let mockClient2
 
 const Wrapper = props => (
   <ClientContext.Provider value={mockClient}>
@@ -32,6 +33,17 @@ describe('useClientRequest', () => {
       },
       request: jest.fn().mockResolvedValue({ data: 'data' })
     }
+
+    mockClient2 = {
+      getCacheKey: jest.fn().mockReturnValue('cacheKey'),
+      getCache: jest.fn(),
+      saveCache: jest.fn(),
+      cache: {
+        get: jest.fn(),
+        set: jest.fn()
+      },
+      request: jest.fn().mockResolvedValue({ data: 'data' })
+    }
   })
 
   it('returns a fetch function & state', () => {
@@ -41,6 +53,21 @@ describe('useClientRequest', () => {
     })
     expect(fetchData).toEqual(expect.any(Function))
     expect(state).toEqual({ cacheHit: false, loading: true })
+  })
+
+  it('uses a passed client', async () => {
+    const options = { isMutation: false, client: mockClient2 }
+    let fetchData
+    renderHook(() => ([fetchData] = useClientRequest(TEST_QUERY, options)), {
+      wrapper: Wrapper
+    })
+
+    await act(fetchData)
+
+    expect(mockClient2.request).toHaveBeenCalledWith(
+      { query: TEST_QUERY },
+      options
+    )
   })
 
   it('resets data when query or variables change', async () => {

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -4,7 +4,6 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import { useClientRequest, ClientContext } from '../../src'
 
 let mockClient
-let mockClient2
 
 const Wrapper = props => (
   <ClientContext.Provider value={mockClient}>
@@ -33,17 +32,6 @@ describe('useClientRequest', () => {
       },
       request: jest.fn().mockResolvedValue({ data: 'data' })
     }
-
-    mockClient2 = {
-      getCacheKey: jest.fn().mockReturnValue('cacheKey'),
-      getCache: jest.fn(),
-      saveCache: jest.fn(),
-      cache: {
-        get: jest.fn(),
-        set: jest.fn()
-      },
-      request: jest.fn().mockResolvedValue({ data: 'data' })
-    }
   })
 
   it('returns a fetch function & state', () => {
@@ -56,6 +44,16 @@ describe('useClientRequest', () => {
   })
 
   it('uses a passed client', async () => {
+    const mockClient2 = {
+      getCacheKey: jest.fn().mockReturnValue('cacheKey'),
+      getCache: jest.fn(),
+      saveCache: jest.fn(),
+      cache: {
+        get: jest.fn(),
+        set: jest.fn()
+      },
+      request: jest.fn().mockResolvedValue({ data: 'data' })
+    }
     const options = { isMutation: false, client: mockClient2 }
     let fetchData
     renderHook(() => ([fetchData] = useClientRequest(TEST_QUERY, options)), {


### PR DESCRIPTION
### What does this PR do?

Allows passing a `GraphqlClient` to `useQuery`, `useSubscription`, and `useMutation`. It overrides any `ClientContext`.

### Related issues

Fixes #374

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
