### PR TITLE
fix: clear errors on refetch via loading action

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -14,7 +14,7 @@ function reducer(state, action) {
     case actionTypes.RESET_STATE:
       return action.initialState
     case actionTypes.LOADING:
-      // if previous action resulted in error - refetch will reset the state
+      // if the previous action resulted in an error - refetch should clear any errors
       if (state.error) {
         return {
           ...action.initialState,

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -510,7 +510,9 @@ describe('useClientRequest', () => {
 
         await act(fetchData)
 
-        mockClient.request.mockResolvedValueOnce({ errors: ['on no!'] })
+        mockClient.request.mockResolvedValueOnce({
+          error: { graphQLErrors: ['on no!'] }
+        })
         await act(() => fetchData({ variables: { limit: 20 } }))
 
         expect(updateDataMock).not.toHaveBeenCalled()

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -102,7 +102,7 @@ describe('useClientRequest', () => {
     })
   })
 
-  it('does reset data if previous call resulted in error', async () => {
+  it('should clear errors when calling fetchData', async () => {
     let fetchData
     let state
 
@@ -117,15 +117,19 @@ describe('useClientRequest', () => {
     )
 
     mockClient.request.mockResolvedValueOnce({
-      error: true,
-      errors: ['oh no!']
+      data: 'data', // ensure data is maintained
+      error: {
+        graphQLErrors: ['oh no!']
+      }
     })
 
     await fetchData()
     expect(state).toEqual({
       cacheHit: false,
-      error: true,
-      errors: ['oh no!'],
+      data: 'data',
+      error: {
+        graphQLErrors: ['oh no!']
+      },
       loading: false
     })
 
@@ -137,7 +141,7 @@ describe('useClientRequest', () => {
     mockClient.request.mockResolvedValueOnce(promise)
     fetchData()
 
-    expect(state).toEqual({ cacheHit: false, loading: true })
+    expect(state).toEqual({ cacheHit: false, loading: true, data: 'data' })
     promiseResolve()
   })
 

--- a/packages/graphql-hooks/test/unit/useQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useQuery.test.js
@@ -156,7 +156,7 @@ describe('useQuery', () => {
   })
 
   it('does not add query to ssrPromises when in ssrMode if there is an error', () => {
-    mockState.error = true
+    mockState.error = { graphQLErrors: ['bad thing'] }
     mockClient.ssrMode = true
     mockQueryReq.mockResolvedValueOnce('data')
     renderHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper })
@@ -206,7 +206,7 @@ describe('useQuery', () => {
     const { rerender } = renderHook(() => useQuery(TEST_QUERY, options), {
       wrapper: Wrapper
     })
-    mockState.error = true
+    mockState.error = { graphQLErrors: ['bad thing'] }
     options.variables.limit = 3
     rerender()
     expect(mockQueryReq).toHaveBeenCalledTimes(2)
@@ -238,7 +238,7 @@ describe('useQuery', () => {
     const { rerender } = renderHook(() => useQuery(TEST_QUERY, options), {
       wrapper: Wrapper
     })
-    mockState.error = true
+    mockState.error = { graphQLErrors: ['bad thing'] }
     options.operationName = 'Operation2'
     rerender()
     expect(mockQueryReq).toHaveBeenCalledTimes(2)
@@ -300,7 +300,7 @@ describe('useQuery', () => {
     const { rerender } = renderHook(() => useQuery(query), {
       wrapper: Wrapper
     })
-    mockState.error = true
+    mockState.error = { graphQLErrors: ['bad thing'] }
     query = ANOTHER_TEST_QUERY
     rerender()
     expect(mockQueryReq).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
### What does this PR do?

Once we go into the loading state we can check if the previous state includes any error, if so we reset it to the initial state.

### Related issues

Solves https://github.com/nearform/graphql-hooks/issues/313

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
