### PR TITLE
Populate error information during SSR

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -180,7 +180,8 @@ function useClientRequest(query, initialOpts = {}) {
             const cacheValue = {
               data: revisedOpts.updateData
                 ? revisedOpts.updateData(state.data, actionResult.data)
-                : actionResult.data
+                : actionResult.data,
+              error: actionResult.error
             }
             client.saveCache(revisedCacheKey, cacheValue)
           }


### PR DESCRIPTION
The problem is described in #434

### What does this PR do?

During SSR rendering the fetch Promise is stored inside an array and will be resolved later. If an graphql error occurs during this fetch, there is no possibility to see this error during the SSRendering. 

My PR stores the error information in the cache (ONLY FOR SSR) and populate this error information back to the caller.

