### PR TITLE
fix(deps): fnv1a included which supports Safari

### DIFF
--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-hooks-memcache",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "In memory cache for graphql-hooks",
   "main": "lib/graphql-hooks-memcache.js",
   "module": "es/graphql-hooks-memcache.js",
@@ -31,7 +31,6 @@
   "author": "Brian Mullan <bmullan91@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@sindresorhus/fnv1a": "^1.2.0",
     "tiny-lru": "^7.0.0"
   },
   "repository": {

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -31,7 +31,7 @@
   "author": "Brian Mullan <bmullan91@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@sindresorhus/fnv1a": "^2.0.0",
+    "@sindresorhus/fnv1a": "^1.2.0",
     "tiny-lru": "^7.0.0"
   },
   "repository": {

--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-hooks-memcache",
-  "version": "1.3.3",
+  "version": "1.3.2",
   "description": "In memory cache for graphql-hooks",
   "main": "lib/graphql-hooks-memcache.js",
   "module": "es/graphql-hooks-memcache.js",

--- a/packages/graphql-hooks-memcache/src/fnv1a.js
+++ b/packages/graphql-hooks-memcache/src/fnv1a.js
@@ -1,0 +1,62 @@
+'use strict'
+
+// MIT License
+//
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const OFFSET_BASIS_32 = 2166136261
+
+function fnv1aString(string) {
+  let hash = OFFSET_BASIS_32
+
+  for (let i = 0; i < string.length; i++) {
+    hash ^= string.charCodeAt(i)
+
+    // 32-bit FNV prime: 2**24 + 2**8 + 0x93 = 16777619
+    // Using bitshift for accuracy and performance. Numbers in JS suck.
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+  }
+
+  return hash >>> 0
+}
+
+function fnv1aBuffer(buf) {
+  let hash = OFFSET_BASIS_32
+
+  for (let i = 0; i < buf.length; ) {
+    hash ^= buf[i++]
+
+    // 32-bit FNV prime: 2**24 + 2**8 + 0x93 = 16777619
+    // Using bitshift for accuracy and performance. Numbers in JS suck.
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+  }
+
+  return hash >>> 0
+}
+
+export default function fnv1a(input) {
+  if (input instanceof Buffer) {
+    return fnv1aBuffer(input)
+  } else if (typeof input === 'string') {
+    return fnv1aString(input)
+  } else {
+    throw new Error('input must be a string or a Buffer')
+  }
+}

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -1,5 +1,5 @@
 import LRU from 'tiny-lru'
-import fnv1a from '@sindresorhus/fnv1a'
+import fnv1a from './fnv1a'
 
 function generateKey(keyObj) {
   return fnv1a(JSON.stringify(keyObj)).toString(36)

--- a/packages/graphql-hooks-memcache/test/fnv1a.test.js
+++ b/packages/graphql-hooks-memcache/test/fnv1a.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+// MIT License
+//
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import fnv1a from '../src/fnv1a'
+
+describe('fnv1a tests', () => {
+  it('works for string', () => {
+    expect(fnv1a('')).toEqual(2166136261)
+    expect(fnv1a('🦄🌈')).toEqual(582881315)
+    expect(fnv1a('h')).toEqual(3977000791)
+    expect(fnv1a('he')).toEqual(1547363254)
+    expect(fnv1a('hel')).toEqual(179613742)
+    expect(fnv1a('hell')).toEqual(477198310)
+    expect(fnv1a('hello')).toEqual(1335831723)
+    expect(fnv1a('hello ')).toEqual(3801292497)
+    expect(fnv1a('hello w')).toEqual(1402552146)
+    expect(fnv1a('hello wo')).toEqual(3611200775)
+    expect(fnv1a('hello wor')).toEqual(1282977583)
+    expect(fnv1a('hello worl')).toEqual(2767971961)
+    expect(fnv1a('hello world')).toEqual(3582672807)
+    expect(
+      fnv1a(
+        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.'
+      )
+    ).toEqual(2964896417)
+  })
+
+  it('works for buffer', () => {
+    expect(fnv1a(Buffer.from(''))).toEqual(2166136261)
+    expect(fnv1a(Buffer.from('🦄🌈'))).toEqual(2868248295)
+    expect(fnv1a(Buffer.from('h'))).toEqual(3977000791)
+    expect(fnv1a(Buffer.from('he'))).toEqual(1547363254)
+    expect(fnv1a(Buffer.from('hel'))).toEqual(179613742)
+    expect(fnv1a(Buffer.from('hell'))).toEqual(477198310)
+    expect(fnv1a(Buffer.from('hello'))).toEqual(1335831723)
+    expect(fnv1a(Buffer.from('hello '))).toEqual(3801292497)
+    expect(fnv1a(Buffer.from('hello w'))).toEqual(1402552146)
+    expect(fnv1a(Buffer.from('hello wo'))).toEqual(3611200775)
+    expect(fnv1a(Buffer.from('hello wor'))).toEqual(1282977583)
+    expect(fnv1a(Buffer.from('hello worl'))).toEqual(2767971961)
+    expect(fnv1a(Buffer.from('hello world'))).toEqual(3582672807)
+    expect(
+      fnv1a(
+        Buffer.from(
+          'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.'
+        )
+      )
+    ).toEqual(2964896417)
+  })
+
+  it("can't hash objects", () => {
+    expect(() => fnv1a({})).toThrow(Error)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

This PR fix [issue 496](https://github.com/nearform/graphql-hooks/issues/496) which supports Safari

### Checklist

- [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
