### PR TITLE
feat: adding reset function after useMutation

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -50,7 +50,7 @@ export function useClientRequest<
 ): [
   FetchData<ResponseData, Variables, TGraphQLError>,
   UseClientRequestResult<ResponseData, TGraphQLError>,
-  ResetData
+  () => void
 ]
 
 export function useQuery<
@@ -181,8 +181,6 @@ interface UseSubscriptionOperation extends Operation {
 type FetchData<ResponseData, Variables = object, TGraphQLError = object> = (
   options?: UseClientRequestOptions<Variables>
 ) => Promise<UseClientRequestResult<ResponseData, TGraphQLError>>
-
-type ResetData = () => void
 
 interface CacheKeyObject {
   operation: Operation

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -50,7 +50,7 @@ export function useClientRequest<
 ): [
   FetchData<ResponseData, Variables, TGraphQLError>,
   UseClientRequestResult<ResponseData, TGraphQLError>,
-  () => void
+  ResetFunction
 ]
 
 export function useQuery<
@@ -65,12 +65,12 @@ export function useQuery<
 export function useManualQuery<ResponseData = any, Variables = object, TGraphQLError = object>(
   query: string,
   options?: UseClientRequestOptions<Variables>
-): [FetchData<ResponseData, Variables, TGraphQLError>, UseClientRequestResult<ResponseData, TGraphQLError>]
+): [FetchData<ResponseData, Variables, TGraphQLError>, UseClientRequestResult<ResponseData, TGraphQLError>, ResetFunction]
 
 export function useMutation<ResponseData = any, Variables = object, TGraphQLError = object>(
   query: string,
   options?: UseClientRequestOptions<Variables>
-): [FetchData<ResponseData, Variables, TGraphQLError>, UseClientRequestResult<ResponseData, TGraphQLError>]
+): [FetchData<ResponseData, Variables, TGraphQLError>, UseClientRequestResult<ResponseData, TGraphQLError>, ResetFunction]
 
 export interface SubscriptionRequest {
   query: string
@@ -85,6 +85,8 @@ export function useSubscription(
 export const ClientContext: React.Context<GraphQLClient>
 
 // internal types
+
+type ResetFunction = (desiredState?: object) => void
 
 interface ClientOptions {
   url: string

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -49,7 +49,8 @@ export function useClientRequest<
   options?: UseClientRequestOptions<Variables>
 ): [
   FetchData<ResponseData, Variables, TGraphQLError>,
-  UseClientRequestResult<ResponseData, TGraphQLError>
+  UseClientRequestResult<ResponseData, TGraphQLError>,
+  ResetData
 ]
 
 export function useQuery<
@@ -180,6 +181,8 @@ interface UseSubscriptionOperation extends Operation {
 type FetchData<ResponseData, Variables = object, TGraphQLError = object> = (
   options?: UseClientRequestOptions<Variables>
 ) => Promise<UseClientRequestResult<ResponseData, TGraphQLError>>
+
+type ResetData = () => void
 
 interface CacheKeyObject {
   operation: Operation

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -208,7 +208,9 @@ function useClientRequest(query, initialOpts = {}) {
     }
   }, [client, state])
 
-  return [fetchData, state]
+  const reset = () => dispatch({ type: actionTypes.RESET_STATE, initialState })
+
+  return [fetchData, state, reset]
 }
 
 export default useClientRequest

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -208,7 +208,11 @@ function useClientRequest(query, initialOpts = {}) {
     }
   }, [client, state])
 
-  const reset = () => dispatch({ type: actionTypes.RESET_STATE, initialState })
+  const reset = (desiredState = {}) =>
+    dispatch({
+      type: actionTypes.RESET_STATE,
+      initialState: { ...initialState, ...desiredState }
+    })
 
   return [fetchData, state, reset]
 }

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -68,6 +68,30 @@ describe('useClientRequest', () => {
     )
   })
 
+  it('resets data when reset function is called', async () => {
+    let fetchData, state, resetData
+    renderHook(
+      () => ([fetchData, state, resetData] = useClientRequest(TEST_QUERY)),
+      {
+        wrapper: Wrapper
+      }
+    )
+    // initial state
+    expect(state).toEqual({ cacheHit: false, loading: true })
+    await act(fetchData)
+    expect(state).toEqual({
+      cacheHit: false,
+      loading: false,
+      data: 'data'
+    })
+    await act(resetData)
+    // should be back to initial state
+    expect(state).toEqual({
+      cacheHit: false,
+      loading: true
+    })
+  })
+
   it('resets data when query or variables change', async () => {
     let fetchData
     let state

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -92,6 +92,31 @@ describe('useClientRequest', () => {
     })
   })
 
+  it('resets state preserving previous data when reset function is called', async () => {
+    let fetchData, state, resetData
+    renderHook(
+      () => ([fetchData, state, resetData] = useClientRequest(TEST_QUERY)),
+      {
+        wrapper: Wrapper
+      }
+    )
+    // initial state
+    expect(state).toEqual({ cacheHit: false, loading: true })
+    await act(fetchData)
+    expect(state).toEqual({
+      cacheHit: false,
+      loading: false,
+      data: 'data'
+    })
+    await act(() => resetData({ data: 'my previous data' }))
+    // should be back to initial state with previous data
+    expect(state).toEqual({
+      cacheHit: false,
+      loading: true,
+      data: 'my previous data'
+    })
+  })
+
   it('resets data when query or variables change', async () => {
     let fetchData
     let state


### PR DESCRIPTION
### What does this PR do?

This PR introduces the ability to trigger a reset. See [Issue #494](https://github.com/nearform/graphql-hooks/issues/494)

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
