### PR TITLE
fix: including error when cached in SSR

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -178,6 +178,7 @@ function useClientRequest(query, initialOpts = {}) {
 
           if (client.ssrMode) {
             const cacheValue = {
+              error: actionResult.error,
               data: revisedOpts.updateData
                 ? revisedOpts.updateData(state.data, actionResult.data)
                 : actionResult.data


### PR DESCRIPTION
### What does this PR do?

It is the same idea behind https://github.com/nearform/graphql-hooks/pull/478
The unit test for this scenario is included

### Related issues

Related to [Issue #434](https://github.com/nearform/graphql-hooks/issues/434)

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
