### PR TITLE
feat: added debug cache, rawToKey, and rawGet functions to memcache

### DIFF
--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -5,8 +5,14 @@ function generateKey(keyObj) {
   return fnv1a(JSON.stringify(keyObj)).toString(36)
 }
 
-export default function memCache({ size = 100, ttl = 0, initialState } = {}) {
+export default function memCache({
+  size = 100,
+  ttl = 0,
+  debug = false,
+  initialState
+} = {}) {
   const lru = LRU(size, ttl)
+  const debugLru = debug ? LRU(size, ttl) : undefined
 
   if (initialState) {
     Object.keys(initialState).map(k => {
@@ -16,7 +22,20 @@ export default function memCache({ size = 100, ttl = 0, initialState } = {}) {
 
   return {
     get: keyObj => lru.get(generateKey(keyObj)),
-    set: (keyObj, data) => lru.set(generateKey(keyObj), data),
+    rawGet: rawKey => lru.get(rawKey),
+    rawToKey: rawKey => {
+      if (!debugLru) {
+        throw 'not allowed unless in debug mode'
+      }
+      return debugLru.get(rawKey)
+    },
+    set: (keyObj, data) => {
+      const key = generateKey(keyObj)
+      lru.set(key, data)
+      if (debugLru) {
+        debugLru.set(key, keyObj)
+      }
+    },
     delete: keyObj => lru.delete(generateKey(keyObj)),
     clear: () => lru.clear(),
     keys: () => lru.keys(),

--- a/packages/graphql-hooks-memcache/test/index.test.js
+++ b/packages/graphql-hooks-memcache/test/index.test.js
@@ -13,6 +13,11 @@ describe('memcache', () => {
     cache.set({ foo: 'foo' }, 'baz')
     expect(cache.get({ foo: 'foo' })).toEqual('baz')
   })
+  it('gets value from a hashed key', () => {
+    cache.set('foo', 'bar')
+    const rawKey = cache.keys().pop()
+    expect(cache.rawGet(rawKey)).toEqual('bar')
+  })
   it('deletes a key', () => {
     cache.set('foo', 'baz')
     expect(cache.get('foo')).toEqual('baz')
@@ -34,5 +39,20 @@ describe('memcache', () => {
   it('returns initial state', () => {
     cache = memCache({ initialState: { foo: 'bar' } })
     expect(cache.getInitialState()).toEqual({ foo: 'bar' })
+  })
+  it('throws an error if rawToKey is used', () => {
+    expect(() => cache.rawToKey('test')).toThrow()
+  })
+})
+
+describe('memcache (debug)', () => {
+  let cache
+  beforeEach(() => {
+    cache = memCache({ debug: true })
+  })
+  it('returns the original key', () => {
+    cache.set('foo', 'bar')
+    const rawKey = cache.keys().pop()
+    expect(cache.rawToKey(rawKey)).toEqual('foo')
   })
 })


### PR DESCRIPTION
### Summary

- Adds a `debug` option to memCache, disabled by default. When enabled, a second cache is created to allow retrieval of the original key from the hashed representation.
- Adds `rawGet` and `rawToKey` functions to memCache for retrieving values and original keys using hashed keys i.e. those returned by `.keys()`. The `rawToKey` function can only be used when `debug` is specified on the cache, otherwise it will throw an error.

### Related issues

https://github.com/nearform/graphql-hooks/issues/327

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
