### PR TITLE
fix: correct types for useSubscription

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SubscriptionClient } from 'subscriptions-transport-ws';
+import { SubscriptionClient } from 'subscriptions-transport-ws'
 
 // Exports
 
@@ -62,24 +62,47 @@ export function useQuery<
   options?: UseQueryOptions<Variables>
 ): UseQueryResult<ResponseData, Variables, TGraphQLError>
 
-export function useManualQuery<ResponseData = any, Variables = object, TGraphQLError = object>(
+export function useManualQuery<
+  ResponseData = any,
+  Variables = object,
+  TGraphQLError = object
+>(
   query: string,
   options?: UseClientRequestOptions<Variables>
-): [FetchData<ResponseData, Variables, TGraphQLError>, UseClientRequestResult<ResponseData, TGraphQLError>, ResetFunction]
+): [
+  FetchData<ResponseData, Variables, TGraphQLError>,
+  UseClientRequestResult<ResponseData, TGraphQLError>,
+  ResetFunction
+]
 
-export function useMutation<ResponseData = any, Variables = object, TGraphQLError = object>(
+export function useMutation<
+  ResponseData = any,
+  Variables = object,
+  TGraphQLError = object
+>(
   query: string,
   options?: UseClientRequestOptions<Variables>
-): [FetchData<ResponseData, Variables, TGraphQLError>, UseClientRequestResult<ResponseData, TGraphQLError>, ResetFunction]
+): [
+  FetchData<ResponseData, Variables, TGraphQLError>,
+  UseClientRequestResult<ResponseData, TGraphQLError>,
+  ResetFunction
+]
 
 export interface SubscriptionRequest {
   query: string
   variables: object
 }
 
-export function useSubscription(
-  operation: UseSubscriptionOperation,
-  callback: (response: Result) => void
+export function useSubscription<
+  ResponseData = any,
+  Variables extends object = object,
+  TGraphQLError = object
+>(
+  operation: UseSubscriptionOperation<Variables>,
+  callback: (response: {
+    data?: ResponseData
+    errors?: TGraphQLError[]
+  }) => void
 ): void
 
 export const ClientContext: React.Context<GraphQLClient>
@@ -176,8 +199,10 @@ interface UseQueryResult<
   ): Promise<UseClientRequestResult<ResponseData, TGraphQLError>>
 }
 
-interface UseSubscriptionOperation extends Operation {
-  client?: GraphqlClient
+interface UseSubscriptionOperation<Variables extends object = object>
+  extends Operation {
+  variables?: Variables
+  client?: GraphQLClient
 }
 
 type FetchData<ResponseData, Variables = object, TGraphQLError = object> = (


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of what this pull request is for, please provide any background -->
Right now useSubscription callback uses `Result` type which has `error` and `data` fields.

But in reality callback will called with `{ data, errors }`. This PR fixes type mismatch. Also, I've added generics for Response and Variables similar to useQuery and useMutation.

Also includes changes from https://github.com/nearform/graphql-hooks/pull/504/ and solves https://github.com/nearform/graphql-hooks/issues/491

In future maybe it's better to convert subscription result to `{ data, error }` format? It'll be breaking change. Also, errors are not handled by `onError` method of `GraphQLClient`

### Related issues

<!-- Link to any related issues here -->

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
