### PR TITLE
Fixed useQuery returning undefined on initial render

### DIFF
--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -34,6 +34,7 @@ function useQuery(query, opts = {}) {
 
   return {
     ...state,
+    data: state.data ? state.data : {},
     refetch: React.useCallback(
       (options = {}) =>
         queryReq({

--- a/packages/graphql-hooks/test/integration/useQuery.test.js
+++ b/packages/graphql-hooks/test/integration/useQuery.test.js
@@ -21,7 +21,7 @@ const TestComponent = ({ query = '{ hello }', options }) => {
     <div>
       {loading && <div data-testid="loading">Loading...</div>}
       {error && <div data-testid="error">Error</div>}
-      {data && <div data-testid="data">{data}</div>}
+      {data && <div data-testid="data">{JSON.stringify(data)}</div>}
     </div>
   )
 }
@@ -54,7 +54,7 @@ describe('useQuery Integrations', () => {
     // loading -> data
     expect(getByTestId('loading')).toBeTruthy()
     dataNode = await waitForElement(() => getByTestId('data'))
-    expect(dataNode.textContent).toBe('data v1')
+    expect(dataNode.textContent).toBe('"data v1"')
     expect(() => getByTestId('loading')).toThrow()
 
     // second render
@@ -63,9 +63,9 @@ describe('useQuery Integrations', () => {
     rerender(<TestComponent query={'{ goodbye }'} />, { wrapper })
 
     expect(getByTestId('loading')).toBeTruthy()
-    expect(() => getByTestId('data')).toThrow()
+    expect(getByTestId('data').textContent).toBe('{}')
     dataNode = await waitForElement(() => getByTestId('data'))
-    expect(dataNode.textContent).toBe('data v2')
+    expect(dataNode.textContent).toBe('"data v2"')
     expect(() => getByTestId('loading')).toThrow()
 
     // 1. loading
@@ -90,7 +90,7 @@ describe('useQuery Integrations', () => {
     // loading -> data
     expect(getByTestId('loading')).toBeTruthy()
     dataNode = await waitForElement(() => getByTestId('data'))
-    expect(dataNode.textContent).toBe('data v1')
+    expect(dataNode.textContent).toBe('"data v1"')
     expect(() => getByTestId('loading')).toThrow()
 
     // second render
@@ -101,9 +101,8 @@ describe('useQuery Integrations', () => {
     rerender(<TestComponent options={options} />, { wrapper })
 
     expect(getByTestId('loading')).toBeTruthy()
-    expect(() => getByTestId('data')).toThrow()
     dataNode = await waitForElement(() => getByTestId('data'))
-    expect(dataNode.textContent).toBe('data v2')
+    expect(dataNode.textContent).toBe('"data v2"')
     expect(() => getByTestId('loading')).toThrow()
 
     // 1. loading
@@ -136,7 +135,7 @@ describe('useQuery Integrations', () => {
     })
 
     expect(() => getByTestId('loading')).toThrow()
-    expect(getByTestId('data').textContent).toBe('hello')
+    expect(getByTestId('data').textContent).toBe('"hello"')
     expect(testComponentRenderCount).toBe(1)
   })
 })

--- a/packages/graphql-hooks/test/unit/useQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useQuery.test.js
@@ -75,7 +75,8 @@ describe('useQuery', () => {
     expect(state).toEqual({
       loading: true,
       cacheHit: false,
-      refetch: expect.any(Function)
+      refetch: expect.any(Function),
+      data: {}
     })
   })
 


### PR DESCRIPTION
### Summary

- Changes `useQuery` so that if `data` is `undefined` an empty object is returned instead, this usually happens on the initial component render and should also resolve issue #444
- Note that the change might be breaking for some users who are relying on the old behaviour where the data is initially undefined. For example, loose assertions like this will no longer work:

```jsx
if (!data) return <div>Loading</div>
```
### Related issues

https://github.com/nearform/graphql-hooks/issues/517
https://github.com/nearform/graphql-hooks/issues/444

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
