### PR TITLE
Feature/334 normalized cache

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,11 @@ const projects = [
     roots: ['./packages/graphql-hooks-ssr'],
     displayName: 'graphql-hooks-ssr',
     testMatch: ['<rootDir>/packages/graphql-hooks-ssr/**/*.test.js']
+  },
+  {
+    roots: ['./packages/graphql-hooks-normcache'],
+    displayName: 'graphql-hooks-normcache',
+    testMatch: ['<rootDir>/packages/graphql-hooks-normcache/**/*.test.js']
   }
 ]
 module.exports = {

--- a/packages/graphql-hooks-normcache/README.md
+++ b/packages/graphql-hooks-normcache/README.md
@@ -1,0 +1,42 @@
+# graphql-hooks-normcache
+
+In-memory normalized cache implementation for graphql-hooks
+
+## Install
+
+`npm install graphql-hooks-normcache`
+
+or
+
+`yarn add graphql-hooks-normcache`
+
+## Quick Start
+
+This is intended to be used as the `cache` option when calling `createClient` from `graphql-hooks`.
+
+```js
+import { GraphQLClient } from 'graphql-hooks'
+import normCache from 'graphql-hooks-normcache'
+
+const client = new GraphQLClient({
+  url: '/graphql',
+  cache: normCache()
+})
+```
+
+### Options
+
+`normCache(options)`: Option object properties
+
+- `size`: The number of items to store in the cache
+- `ttl`: Milliseconds an item will remain in cache. The default behaviour will only evict items when the `size` limit has been reached
+- `initialState`: The value from `cache.getInitialState()` used for rehydrating the cache after SSR
+
+### API
+
+- `cache.get(key)`: Find the item in the cache that matches `key`
+- `cache.set(key, value)`: Set an item in the cache
+- `cache.delete(key)`: Does nothing
+- `cache.clear()`: Clear all items from the cache
+- `cache.keys()`: Returns an array of keys, useful when you need to iterate over the cache items
+- `cache.getInitialState()`: A serialisable version of the cache - used during SSR

--- a/packages/graphql-hooks-normcache/index.d.ts
+++ b/packages/graphql-hooks-normcache/index.d.ts
@@ -1,0 +1,16 @@
+export = NormCacheFunction
+
+declare function NormCacheFunction(options?: {
+  size?: number
+  ttl?: number
+  initialState?: object
+}): NormCache
+
+interface NormCache {
+  get(keyObject: object): object
+  set(keyObject: object, data: object): void
+  delete(keyObject: object): void
+  clear(): void
+  keys(): void
+  getInitialState(): object
+}

--- a/packages/graphql-hooks-normcache/package.json
+++ b/packages/graphql-hooks-normcache/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "graphql-hooks-normcache",
+  "version": "1.0.0",
+  "description": "Normalized in memory cache for graphql-hooks",
+  "main": "lib/graphql-hooks-normcache.js",
+  "module": "es/graphql-hooks-normcache.js",
+  "unpkg": "dist/graphql-hooks-normcache.min.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "clean": "rm -rf ./dist ./es ./lib",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "rollup -c",
+    "prepublishOnly": "npm run build && cp ../../LICENSE ."
+  },
+  "files": [
+    "dist",
+    "es",
+    "lib",
+    "src",
+    "index.d.ts"
+  ],
+  "keywords": [
+    "graphql",
+    "hooks",
+    "react",
+    "graphql-hooks",
+    "cache",
+    "ssr",
+    "server-side rendering"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "graphql": "^15.0.0",
+    "graphql-norm": "^1.3.6",
+    "graphql-tag": "^2.10.3",
+    "tiny-lru": "^7.0.4"
+  },
+  "devDependencies": {
+    "rollup": "^2.13.1"
+  }
+}

--- a/packages/graphql-hooks-normcache/rollup.config.js
+++ b/packages/graphql-hooks-normcache/rollup.config.js
@@ -1,0 +1,10 @@
+import generateRollupConfig from '../../config/rollup.config'
+
+const pkg = require('./package.json')
+const externalPeerDeps = [...Object.keys(pkg.peerDependencies || {})]
+
+const overrides = {
+  external: [...externalPeerDeps, 'graphql-norm', 'graphql-tag', 'tiny-lru']
+}
+
+export default generateRollupConfig('GraphQLHooksNormcache', overrides)

--- a/packages/graphql-hooks-normcache/src/index.js
+++ b/packages/graphql-hooks-normcache/src/index.js
@@ -1,0 +1,68 @@
+import LRU from 'tiny-lru'
+import { normalize, denormalize } from 'graphql-norm'
+import parse from 'graphql-tag'
+
+const objToKey = obj =>
+  obj.code && obj.__typename && `${obj.__typename}:${obj.code}`
+
+const normalizeData = ({ query, variables, data }) =>
+  normalize(parse(query), variables, data, objToKey)
+
+const denormalizeData = ({ query, variables, cache }) =>
+  denormalize(parse(query), variables, cache)
+
+export default function normCache({ size = 100, ttl = 0, initialState } = {}) {
+  const lru = LRU(size, ttl)
+
+  // Proxy required for denormalize because it uses the [] operator
+  const proxy = new Proxy(lru, {
+    get: (cache, key) => cache.get(key),
+    ownKeys: cache => cache.keys(),
+    enumerate: cache => cache.keys()
+  })
+
+  if (initialState) {
+    Object.keys(initialState).forEach(k => lru.set(k, initialState[k]))
+  }
+
+  return {
+    get: keyObj => {
+      const denormalized = denormalizeData({
+        query: keyObj.operation.query,
+        variables: keyObj.operation.variables,
+        cache: proxy
+      })
+      return (
+        denormalized.data && {
+          data: denormalized.data,
+          error: false
+        }
+      )
+    },
+    rawGet: rawKey => lru.get(rawKey),
+    set: (keyObj, data) => {
+      const updates = normalizeData({
+        query: keyObj.operation.query,
+        variables: keyObj.operation.variables,
+        data: data.data
+      })
+      Object.keys(updates).forEach(key =>
+        lru.set(key, { ...(lru.get(key) || {}), ...updates[key] })
+      )
+    },
+    delete: () => {
+      // Doesn't make sense to implement because cached objects might be
+      // shared between multiple queries
+    },
+    clear: () => lru.clear(),
+    keys: () => lru.keys(),
+    getInitialState: () =>
+      lru.keys().reduce(
+        (initialState, key) => ({
+          ...initialState,
+          [key]: lru.get(key)
+        }),
+        {}
+      )
+  }
+}

--- a/packages/graphql-hooks-normcache/src/index.js
+++ b/packages/graphql-hooks-normcache/src/index.js
@@ -25,7 +25,7 @@ export default function normCache({ size = 100, ttl = 0, initialState } = {}) {
     get: keyObj => {
       const denormalized = denormalizeData({
         query: keyObj.operation.query,
-        variables: keyObj.operation.variables,
+        variables: keyObj.operation.variables || {},
         cache: proxy
       })
       return (
@@ -39,7 +39,7 @@ export default function normCache({ size = 100, ttl = 0, initialState } = {}) {
     set: (keyObj, data) => {
       const updates = normalizeData({
         query: keyObj.operation.query,
-        variables: keyObj.operation.variables,
+        variables: keyObj.operation.variables || {},
         data: data.data
       })
       Object.keys(updates).forEach(key =>

--- a/packages/graphql-hooks-normcache/src/index.js
+++ b/packages/graphql-hooks-normcache/src/index.js
@@ -15,11 +15,7 @@ export default function normCache({ size = 100, ttl = 0, initialState } = {}) {
   const lru = LRU(size, ttl)
 
   // Proxy required for denormalize because it uses the [] operator
-  const proxy = new Proxy(lru, {
-    get: (cache, key) => cache.get(key),
-    ownKeys: cache => cache.keys(),
-    enumerate: cache => cache.keys()
-  })
+  const proxy = new Proxy(lru, { get: (cache, key) => cache.get(key) })
 
   if (initialState) {
     Object.keys(initialState).forEach(k => lru.set(k, initialState[k]))

--- a/packages/graphql-hooks-normcache/test/index.test.js
+++ b/packages/graphql-hooks-normcache/test/index.test.js
@@ -84,6 +84,10 @@ describe('normcache', () => {
     cache.set(testKey, testValue)
     expect(cache.get(testKey)).toEqual(testValue)
   })
+  it('returns undefined on get if key does not exist', () => {
+    cache = normCache()
+    expect(cache.get(testKey)).toBe(undefined)
+  })
   it('gets value from a raw key', () => {
     expect(cache.rawGet('Post:123')).toEqual(initialState['Post:123'])
   })

--- a/packages/graphql-hooks-normcache/test/index.test.js
+++ b/packages/graphql-hooks-normcache/test/index.test.js
@@ -1,0 +1,104 @@
+import normCache from '../src'
+
+const initialState = {
+  ROOT_QUERY: {
+    posts: ['Post:123']
+  },
+  'Post:123': {
+    id: '123',
+    __typename: 'Post',
+    author: 'Author:1',
+    title: 'My awesome blog post',
+    comments: ['Comment:324']
+  },
+  'Author:1': { id: '1', __typename: 'Author', name: 'Paul' },
+  'Comment:324': {
+    id: '324',
+    __typename: 'Comment',
+    commenter: 'Author:2'
+  },
+  'Author:2': { id: '2', __typename: 'Author', name: 'Nicole' }
+}
+
+const testKey = {
+  operation: {
+    query: `query TestQuery {
+            posts {
+            id
+            __typename
+            author {
+                id
+                __typename
+                name
+            }
+            title
+            comments {
+                id
+                __typename
+                commenter {
+                id
+                __typename
+                name
+                }
+            }
+            }
+        }`
+  }
+}
+
+const testValue = {
+  data: {
+    posts: [
+      {
+        id: '123',
+        __typename: 'Post',
+        author: {
+          id: '1',
+          __typename: 'Author',
+          name: 'Paul'
+        },
+        title: 'My awesome blog post',
+        comments: [
+          {
+            id: '324',
+            __typename: 'Comment',
+            commenter: {
+              id: '2',
+              __typename: 'Author',
+              name: 'Nicole'
+            }
+          }
+        ]
+      }
+    ]
+  },
+  error: false
+}
+
+describe('normcache', () => {
+  let cache
+  beforeEach(() => {
+    cache = normCache({ initialState })
+  })
+  it('sets and gets key', () => {
+    cache.set(testKey, testValue)
+    expect(cache.get(testKey)).toEqual(testValue)
+  })
+  it('gets value from a raw key', () => {
+    expect(cache.rawGet('Post:123')).toEqual(initialState['Post:123'])
+  })
+  it('does not throw on delete', () => {
+    expect(() => cache.delete(testKey)).not.toThrow()
+  })
+  it('lists all keys', () => {
+    expect(cache.keys().length).toEqual(5)
+  })
+  it('clears all keys', () => {
+    cache.clear()
+    expect(cache.keys().length).toEqual(0)
+  })
+  it('returns initial state', () => {
+    cache = normCache({ initialState })
+    expect(cache.getInitialState()).toEqual(initialState)
+  })
+})


### PR DESCRIPTION
### Summary

Adds a new package, `graphql-hooks-normcache`, which implements a normalized in-memory LRU cache using `tiny-lru` and `graphql-norm`

### Related issues

https://github.com/nearform/graphql-hooks/issues/334

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
