### PR TITLE
Add mock GraphQL server

### DIFF
--- a/.github/workflows/create-react-app-server.yml
+++ b/.github/workflows/create-react-app-server.yml
@@ -1,0 +1,57 @@
+name: Mock GrapQL Server to GCP
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'examples/create-react-app/**'
+
+jobs:
+  deploy-create-react-app-server:
+    name: Build & Deploy create-react-app-server
+    runs-on: ubuntu-latest
+
+    env:
+      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      CLOUDRUN_SERVICE_NAME: create-react-app-server
+      CLOUDRUN_SERVICE_REGION: europe-west1
+      CI: true
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Set up GCP CLI
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Configure Docker repository
+        run: |
+          echo "::set-env name=DOCKER_IMAGE::gcr.io/$PROJECT_ID/$CLOUDRUN_SERVICE_NAME:$GITHUB_SHA"
+          gcloud auth configure-docker
+      - name: Build container
+        working-directory: ./examples/create-react-app
+        run: |
+          docker build -t $DOCKER_IMAGE .
+      - name: Push container
+        working-directory: ./examples/create-react-app
+        run: |
+          docker push $DOCKER_IMAGE
+      - name: Run service
+        working-directory: ./examples/create-react-app
+        run: |
+          gcloud run deploy $CLOUDRUN_SERVICE_NAME \
+            --image $DOCKER_IMAGE \
+            --region $CLOUDRUN_SERVICE_REGION \
+            --project $PROJECT_ID \
+            --platform managed

--- a/examples/create-react-app/Dockerfile
+++ b/examples/create-react-app/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12-alpine
+
+WORKDIR /service
+
+COPY package.json ./
+COPY server ./server
+COPY public ./public
+
+RUN npm install
+
+USER node
+
+CMD ["npm", "run", "start:server"]

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "graphql-hooks": "^4.5.0",
     "graphql-hooks-memcache": "^1.3.3",
+    "json-graphql-server": "^2.1.3",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-app-polyfill": "^1.0.1",
@@ -15,7 +16,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start:server": "json-graphql-server ./server/db.js --p 3001"
   },
   "browserslist": [
     "ie >= 11"

--- a/examples/create-react-app/server/db.js
+++ b/examples/create-react-app/server/db.js
@@ -1,0 +1,6 @@
+module.exports = {
+  posts: [
+    { id: 1, title: 'Lorem Ipsum', url: 'http://lorum.com' },
+    { id: 2, title: 'Sic Dolor amet', url: 'http://dolor.com' }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react-hooks": "^4.0.0",
     "husky": "^4.2.5",
     "jest": "^26.0.0",
+    "json-graphql-server": "^2.1.3",
     "lerna": "^3.15.0",
     "lint-staged": "^10.0.0",
     "prettier": "^2.0.0",


### PR DESCRIPTION
### What does this PR do?

Adds a mock graphql server to replace graph.cool (since that service is deprecated).
Server is needed to run the `create-react-app` example, but also to run acceptance test.
