### PR TITLE
Replace mock server calls

### DIFF
--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -5,7 +5,7 @@ import Posts from './components/Posts'
 
 const client = new GraphQLClient({
   cache: memCache(),
-  url: 'https://api.graph.cool/simple/v1/cjs4qo29b2w0c0130tfx6maca'
+  url: 'https://create-react-app-server-kqtv5azt3q-ew.a.run.app'
 })
 
 export default function App() {

--- a/examples/create-react-app/src/components/CreatePost.js
+++ b/examples/create-react-app/src/components/CreatePost.js
@@ -4,8 +4,8 @@ import React from 'react'
 import CreatePostForm from './CreatePostForm'
 
 const createPostMutation = `
-  mutation CreatePost($title: String!, $url: String!) {
-    createPost(title: $title, url: $url) {
+  mutation CreatePost($id: ID!, $title: String!, $url: String!) {
+    createPost(id: $id, title: $title, url: $url) {
       id
     }
   }
@@ -15,7 +15,8 @@ export default function CreatePost({ onSuccess }) {
   const [createPost, { loading, error }] = useMutation(createPostMutation)
 
   async function handleSubmit({ title, url }) {
-    await createPost({ variables: { title, url } })
+    const id = Math.floor(Math.random() * 1000000)
+    await createPost({ variables: { id, title, url } })
     onSuccess && onSuccess()
   }
 

--- a/examples/create-react-app/src/components/Posts.js
+++ b/examples/create-react-app/src/components/Posts.js
@@ -5,7 +5,7 @@ import CreatePost from './CreatePost'
 
 export const allPostsQuery = `
   query {
-    allPosts(orderBy: createdAt_DESC, first: 20) {
+    allPosts {
       id
       title
       url

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -15,7 +15,7 @@ interface Post {
 }
 
 const client = new GraphQLClient({
-  url: 'https://api.graph.cool/simple/v1/cjs4qo29b2w0c0130tfx6maca'
+  url: 'https://create-react-app-server-kqtv5azt3q-ew.a.run.app'
 })
 
 export const allPostsQuery = `


### PR DESCRIPTION
### What does this PR do?

Fixes the urls to the mock graphql server (previously graphcool, which is deprecated).
And makes acceptance test work again
