### PR TITLE
fix: response data is optional

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -185,7 +185,7 @@ interface UseQueryOptions<Variables = object>
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {
   loading: boolean
   cacheHit: boolean
-  data: ResponseData
+  data?: ResponseData
   error?: APIError<TGraphQLError>
 }
 


### PR DESCRIPTION
### What does this PR do?

The `useQuery` is returning `undefined` for `data` on the first render, but this is not reflected in the typescript types. This PR changes the type to optional.

Although there is a suggestion #517 (and a PR #521) to change the `data` to always be an empty object, this would not be preferred, because that would cause a re-render.

### Related issues

- #517 
- #444 


