### PR TITLE
chore: reduce renovate noise

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -3,16 +3,16 @@
   "version": "2.0.0",
   "private": true,
   "dependencies": {
-    "@types/jest": "26.0.15",
-    "@types/node": "11.15.35",
-    "@types/react": "16.9.55",
-    "@types/react-dom": "16.9.9",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^11.15.35",
+    "@types/react": "^16.9.55",
+    "@types/react-dom": "^16.9.9",
     "graphql-hooks": "^5.0.0",
     "graphql-hooks-memcache": "^2.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "react-scripts": "3.4.4",
-    "typescript": "4.0.5"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-scripts": "^3.4.4",
+    "typescript": "^4.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,11 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "rangeStrategy": "replace",
-  "ignorePaths": [],
-  "includePaths": [
-    "package.json",
-    "packages/**",
-    "examples/**"
-  ],
+  "extends": ["config:base"],
+  "includePaths": ["package.json", "packages/**", "examples/**"],
+  "label": "renovate",
   "packageRules": [
     {
-      "updateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Reduces Renovate noise by:

- automerging all dependency types
- avoid creating PRs for the bumps which pass CI checks so that no notifications are sent
- label Renovate PRs with a "renovate" label

It also unpins dependencies where they were pinned.