### PR TITLE
fix: remove Buffer support from fnv1a

### DIFF
--- a/packages/graphql-hooks-memcache/src/fnv1a.js
+++ b/packages/graphql-hooks-memcache/src/fnv1a.js
@@ -37,26 +37,10 @@ function fnv1aString(string) {
   return hash >>> 0
 }
 
-function fnv1aBuffer(buf) {
-  let hash = OFFSET_BASIS_32
-
-  for (let i = 0; i < buf.length; ) {
-    hash ^= buf[i++]
-
-    // 32-bit FNV prime: 2**24 + 2**8 + 0x93 = 16777619
-    // Using bitshift for accuracy and performance. Numbers in JS suck.
-    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
-  }
-
-  return hash >>> 0
-}
-
 export default function fnv1a(input) {
-  if (input instanceof Buffer) {
-    return fnv1aBuffer(input)
-  } else if (typeof input === 'string') {
+  if (typeof input === 'string') {
     return fnv1aString(input)
   } else {
-    throw new Error('input must be a string or a Buffer')
+    throw new Error('input must be a string')
   }
 }

--- a/packages/graphql-hooks-memcache/test/fnv1a.test.js
+++ b/packages/graphql-hooks-memcache/test/fnv1a.test.js
@@ -45,29 +45,6 @@ describe('fnv1a tests', () => {
     ).toEqual(2964896417)
   })
 
-  it('works for buffer', () => {
-    expect(fnv1a(Buffer.from(''))).toEqual(2166136261)
-    expect(fnv1a(Buffer.from('🦄🌈'))).toEqual(2868248295)
-    expect(fnv1a(Buffer.from('h'))).toEqual(3977000791)
-    expect(fnv1a(Buffer.from('he'))).toEqual(1547363254)
-    expect(fnv1a(Buffer.from('hel'))).toEqual(179613742)
-    expect(fnv1a(Buffer.from('hell'))).toEqual(477198310)
-    expect(fnv1a(Buffer.from('hello'))).toEqual(1335831723)
-    expect(fnv1a(Buffer.from('hello '))).toEqual(3801292497)
-    expect(fnv1a(Buffer.from('hello w'))).toEqual(1402552146)
-    expect(fnv1a(Buffer.from('hello wo'))).toEqual(3611200775)
-    expect(fnv1a(Buffer.from('hello wor'))).toEqual(1282977583)
-    expect(fnv1a(Buffer.from('hello worl'))).toEqual(2767971961)
-    expect(fnv1a(Buffer.from('hello world'))).toEqual(3582672807)
-    expect(
-      fnv1a(
-        Buffer.from(
-          'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.'
-        )
-      )
-    ).toEqual(2964896417)
-  })
-
   it("can't hash objects", () => {
     expect(() => fnv1a({})).toThrow(Error)
   })


### PR DESCRIPTION
### What does this PR do?

Removes support for Buffer in the imported fnv1a library as we don't use it and because it causes issues when Buffer is not polyfilled, which happens by default in Webpack 5.



### Related issues

Fixes #608 

<!-- Link to any related issues here -->

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
