### PR TITLE
Don't require fetch polyfill on server if ssrMode is false

### DIFF
--- a/packages/graphql-hooks/test/unit/GraphQLClient.ssr.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.ssr.test.js
@@ -1,0 +1,21 @@
+import { GraphQLClient } from '../../src'
+
+const validConfig = {
+  url: 'https://my.graphql.api'
+}
+
+beforeAll(() => {
+  delete global.fetch
+})
+
+describe('GraphQLClient', () => {
+  it("doesn't require fetch to be polyfilled when ssrMode is false", () => {
+    expect(global.fetch).toBe(undefined)
+    const client = new GraphQLClient({
+      ...validConfig,
+      ssrMode: false,
+      cache: { get: 'get', set: 'set' }
+    })
+    expect(client.ssrMode).toBe(false)
+  })
+})


### PR DESCRIPTION
Don't error on server if fetch is not polyfilled and `ssrMode` is set to false.


### Related issues

Fixes #620

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation N/A
- [x] I have added or updated any relevant tests