### PR TITLE
feat(typing): make Operation generic to be able to type variables

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -142,9 +142,9 @@ interface Cache {
   getInitialState(): object
 }
 
-interface Operation {
+interface Operation<TVariables = object> {
   query: string
-  variables?: object
+  variables?: TVariables
   operationName?: string
 }
 

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -33,7 +33,7 @@ export class GraphQLClient {
     operation: Operation,
     options: UseClientRequestOptions<Variables>
   ): CacheKeyObject
-  getFetchOptions(operation: Operation, fetchOptionsOverrides?: object): object
+  getFetchOptions<Variables = object>(operation: Operation<Variables>, fetchOptionsOverrides?: object): object
   request<ResponseData, TGraphQLError = object, Variables = object>(
     operation: Operation<Variables>,
     options?: object

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -34,8 +34,8 @@ export class GraphQLClient {
     options: UseClientRequestOptions<Variables>
   ): CacheKeyObject
   getFetchOptions(operation: Operation, fetchOptionsOverrides?: object): object
-  request<ResponseData, TGraphQLError = object>(
-    operation: Operation,
+  request<ResponseData, TGraphQLError = object, Variables = object>(
+    operation: Operation<Variables>,
     options?: object
   ): Promise<Result<ResponseData, TGraphQLError>>
 }


### PR DESCRIPTION
### What does this PR do?

The `Operation` interface currently defines the `variables` field as simply `object`, providing no type safety for variables. This PR adds the possibility to override this typing by means of a generic type param `TVariables`. The `GraphQLClient.request` and `GraphQLClient.getFetchOptions` methods are also extended with a Variables generic type param. The defaults have been set as `object` to ensure backwards compatibility with existing code.

### Related issues

None.

### Checklist

- [X] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [X] I have added or updated any relevant documentation
- [X] I have added or updated any relevant tests
