### PR TITLE
feat(typing): Export RequestOptions interface

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -165,7 +165,7 @@ interface Result<ResponseData = any, TGraphQLError = object> {
   error?: APIError<TGraphQLError>
 }
 
-interface UseClientRequestOptions<Variables = object> {
+export interface UseClientRequestOptions<Variables = object> {
   useCache?: boolean
   isMutation?: boolean
   isManual?: boolean
@@ -177,7 +177,7 @@ interface UseClientRequestOptions<Variables = object> {
   client?: GraphQLClient
 }
 
-interface UseQueryOptions<Variables = object>
+export interface UseQueryOptions<Variables = object>
   extends UseClientRequestOptions<Variables> {
   ssr?: boolean
 }


### PR DESCRIPTION
### What does this PR do?

The exports 2 interfaces so they can be used externally, the reason for doing this is because i am working on a plugin for [graphql-code-generator](https://www.graphql-code-generator.com/) to generate typescript functions with graphql-hooks based on graphql queries

### Checklist

- [X] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
