### PR TITLE
fix: update subscription when options change

### DIFF
--- a/packages/graphql-hooks/src/useSubscription.js
+++ b/packages/graphql-hooks/src/useSubscription.js
@@ -7,15 +7,14 @@ function useSubscription(options, callback) {
   callbackRef.current = callback
 
   const contextClient = useContext(ClientContext)
-  const client = options.client || contextClient
-
-  const request = {
-    query: options.query,
-    variables: options.variables
-  }
 
   useEffect(() => {
-    const observable = client.createSubscription(request)
+    const client = options.client || contextClient
+
+    const observable = client.createSubscription({
+      query: options.query,
+      variables: options.variables
+    })
 
     const subscription = observable.subscribe({
       next: result => {
@@ -32,8 +31,7 @@ function useSubscription(options, callback) {
     return () => {
       subscription.unsubscribe()
     }
-  }, []) // eslint-disable-line
-  // the effect should be run when component is mounted and unmounted
+  }, [contextClient, options])
 }
 
 export default useSubscription


### PR DESCRIPTION
First of all, thank you for such an awesome **simple** library. I loved how easy it is to use and now, hopefully, contribute to it.

### What does this PR do?

This PR fixes a bug by updating the dependency list of `useEffect` hook so that it correctly re-subscribes if any of the options change.

#### Steps to reproduce the bug
1. Call `useSubscription` with valid options.
2. Update the options of `useSubscription` without unmounting the parent component, e.g. by changing the state.

#### Expected outcome
Client correctly re-subscribes.

#### Actual outcome
Client doesn't do anything.

### Our use case

I'm working on a crypto project that interacts with multiple chains (effectively databases) using graphql. For that reason we have the need to have multiple graphql clients. The issue I started running into when migrating from apollo to this awesome lib is that `useSubscription` hook doesn't update when a new client with different query variables is passed in.

I understand that others might have started relying on this "feature" and would be looking for advice to best solve it for our case.

### Related issues

I haven't opened an issue for it and it does not seem to have been raised by anyone else :man_shrugging: 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
