### PR TITLE
feat: add ability to skip query entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This is a custom hook that takes care of fetching your query and storing the res
   - `operationName`: If your query has multiple operations, pass the name of the operation you wish to execute.
   - `persisted`: Boolean - defaults to `false`; Pass `true` if your graphql server supports `persisted` flag to serve persisted queries.
   - `useCache`: Boolean - defaults to `true`; cache the query result
-  - `skip`: Boolean - defaults to `false`; do not trigger the query if set to `true`, the `refetch` function will be a noop function.
+  - `skip`: Boolean - defaults to `false`; do not execute the query if set to `true`
   - `skipCache`: Boolean - defaults to `false`; If `true` it will by-pass the cache and fetch, but the result will then be cached for subsequent calls. Note the `refetch` function will do this automatically
   - `ssr`: Boolean - defaults to `true`. Set to `false` if you wish to skip this query during SSR
   - `fetchOptionsOverrides`: Object - Specific overrides for this query. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) for info on what options can be passed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ function MyComponent() {
 ```
 
 ## Why `graphql-hooks`?
+
 The first thing you may ask when seeing `graphql-hooks` is "Why not use Apollo hooks?".
 It's the comparison most will make. In fact, there's an [article comparing the two](https://blog.logrocket.com/comparing-hooks-libraries-for-graphql/) over on LogRocket.
 
@@ -100,11 +101,11 @@ In terms of performance, this is more of a grey area as we have no official benc
 
 If you need a client that offers middleware and advanced cache configuration, then `apollo-hooks` may work out to be a good choice for your project if bundle size is not an issue.
 
-|Pros | Cons|
-|-----|-----|
-|Small in size|Middleware support|
-|Concise API|Less "advanced" caching configuration|
-|Quick to get up and running|
+| Pros                        | Cons                                  |
+| --------------------------- | ------------------------------------- |
+| Small in size               | Middleware support                    |
+| Concise API                 | Less "advanced" caching configuration |
+| Quick to get up and running |
 
 # Table of Contents
 
@@ -234,6 +235,7 @@ This is a custom hook that takes care of fetching your query and storing the res
   - `operationName`: If your query has multiple operations, pass the name of the operation you wish to execute.
   - `persisted`: Boolean - defaults to `false`; Pass `true` if your graphql server supports `persisted` flag to serve persisted queries.
   - `useCache`: Boolean - defaults to `true`; cache the query result
+  - `skip`: Boolean - defaults to `false`; do not trigger the query if set to `true`, the `refetch` function will be a noop function.
   - `skipCache`: Boolean - defaults to `false`; If `true` it will by-pass the cache and fetch, but the result will then be cached for subsequent calls. Note the `refetch` function will do this automatically
   - `ssr`: Boolean - defaults to `true`. Set to `false` if you wish to skip this query during SSR
   - `fetchOptionsOverrides`: Object - Specific overrides for this query. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) for info on what options can be passed
@@ -389,7 +391,7 @@ First follow the [quick start guide](#Quick-Start) to create the client and povi
 import { GraphQLClient } from 'graphql-hooks'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 // or
-import { createClient } from 'graphql-ws';
+import { createClient } from 'graphql-ws'
 
 const client = new GraphQLClient({
   url: 'http://localhost:8000/graphql',
@@ -539,10 +541,10 @@ const updateData = (prevData, data) => ({
 export default function PostList() {
   const [skipCount, setSkipCount] = useState(0)
 
-  const { loading, error, data } = useQuery(
-    allPostsQuery,
-    { variables: { skip: skipCount, first: 10 }, updateData },
-  )
+  const { loading, error, data } = useQuery(allPostsQuery, {
+    variables: { skip: skipCount, first: 10 },
+    updateData
+  })
 
   if (error) return <div>There was an error!</div>
   if (loading && !data) return <div>Loading</div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,6 @@ const projects = [
     roots: ['./packages/graphql-hooks'],
     testMatch: ['<rootDir>/packages/graphql-hooks/**/*.test.js'],
     setupFiles: ['<rootDir>/packages/graphql-hooks/test/setup.js'],
-    setupFilesAfterEnv: [
-      '<rootDir>/packages/graphql-hooks/test/setupAfterEnv.js'
-    ],
     automock: false,
     testEnvironment: 'jsdom'
   },

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -34,7 +34,10 @@ export class GraphQLClient {
     operation: Operation,
     options: UseClientRequestOptions<Variables>
   ): CacheKeyObject
-  getFetchOptions<Variables = object>(operation: Operation<Variables>, fetchOptionsOverrides?: object): object
+  getFetchOptions<Variables = object>(
+    operation: Operation<Variables>,
+    fetchOptionsOverrides?: object
+  ): object
   request<ResponseData, TGraphQLError = object, Variables = object>(
     operation: Operation<Variables>,
     options?: object
@@ -176,12 +179,12 @@ export interface UseClientRequestOptions<Variables = object> {
   fetchOptionsOverrides?: object
   updateData?(previousData: any, data: any): any
   client?: GraphQLClient
-  skip?: boolean
 }
 
 export interface UseQueryOptions<Variables = object>
   extends UseClientRequestOptions<Variables> {
   ssr?: boolean
+  skip?: boolean
 }
 
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -176,6 +176,7 @@ export interface UseClientRequestOptions<Variables = object> {
   fetchOptionsOverrides?: object
   updateData?(previousData: any, data: any): any
   client?: GraphQLClient
+  skip?: boolean
 }
 
 export interface UseQueryOptions<Variables = object>

--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -19,7 +19,8 @@ function useQuery(query, opts = {}) {
     client.ssrMode &&
     opts.ssr !== false &&
     !calledDuringSSR &&
-    !opts.skipCache
+    !opts.skipCache &&
+    !opts.skip
   ) {
     // result may already be in the cache from previous SSR iterations
     if (!state.data && !state.error) {

--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -4,7 +4,8 @@ import useClientRequest from './useClientRequest'
 import ClientContext from './ClientContext'
 
 const defaultOpts = {
-  useCache: true
+  useCache: true,
+  skip: false
 }
 
 function useQuery(query, opts = {}) {
@@ -29,22 +30,29 @@ function useQuery(query, opts = {}) {
   }
   const stringifiedAllOpts = JSON.stringify(allOpts)
   React.useEffect(() => {
-    queryReq()
+    if (!allOpts.skip) {
+      queryReq()
+    }
   }, [query, stringifiedAllOpts]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     ...state,
     refetch: React.useCallback(
-      (options = {}) =>
-        queryReq({
+      (options = {}) => {
+        // Do not refetch is query is skipped
+        if (allOpts.skip) {
+          return
+        }
+        return queryReq({
           skipCache: true,
           // don't call the updateData that has been passed into useQuery here
           // reset to the default behaviour of returning the raw query result
           // this can be overridden in refetch options
           updateData: (_, data) => data,
           ...options
-        }),
-      [queryReq]
+        })
+      },
+      [allOpts.skip, queryReq]
     )
   }
 }

--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -30,29 +30,26 @@ function useQuery(query, opts = {}) {
   }
   const stringifiedAllOpts = JSON.stringify(allOpts)
   React.useEffect(() => {
-    if (!allOpts.skip) {
-      queryReq()
+    if (allOpts.skip) {
+      return
     }
+
+    queryReq()
   }, [query, stringifiedAllOpts]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     ...state,
     refetch: React.useCallback(
-      (options = {}) => {
-        // Do not refetch is query is skipped
-        if (allOpts.skip) {
-          return
-        }
-        return queryReq({
+      (options = {}) =>
+        queryReq({
           skipCache: true,
           // don't call the updateData that has been passed into useQuery here
           // reset to the default behaviour of returning the raw query result
           // this can be overridden in refetch options
           updateData: (_, data) => data,
           ...options
-        })
-      },
-      [allOpts.skip, queryReq]
+        }),
+      [queryReq]
     )
   }
 }

--- a/packages/graphql-hooks/test/setup.js
+++ b/packages/graphql-hooks/test/setup.js
@@ -1,1 +1,8 @@
 global.fetch = require('jest-fetch-mock')
+// global.console = Object.getOwnPropertyNames(global.console).reduce(
+//   (acc, prop) => ({
+//     ...acc,
+//     [prop]: jest.fn()
+//   }),
+//   {}
+// )

--- a/packages/graphql-hooks/test/setup.js
+++ b/packages/graphql-hooks/test/setup.js
@@ -1,8 +1,1 @@
 global.fetch = require('jest-fetch-mock')
-// global.console = Object.getOwnPropertyNames(global.console).reduce(
-//   (acc, prop) => ({
-//     ...acc,
-//     [prop]: jest.fn()
-//   }),
-//   {}
-// )

--- a/packages/graphql-hooks/test/setupAfterEnv.js
+++ b/packages/graphql-hooks/test/setupAfterEnv.js
@@ -1,1 +1,0 @@
-afterEach(require('@testing-library/react').cleanup)

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -192,7 +192,7 @@ describe('GraphQLClient', () => {
     })
 
     afterEach(() => {
-      jest.restoreAllMocks()
+      jest.clearAllMocks()
     })
 
     it('logs without error', () => {

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -84,7 +84,7 @@ describe('useClientRequest', () => {
       loading: false,
       data: 'data'
     })
-    await act(resetData)
+    act(resetData)
     // should be back to initial state
     expect(state).toEqual({
       cacheHit: false,
@@ -108,7 +108,7 @@ describe('useClientRequest', () => {
       loading: false,
       data: 'data'
     })
-    await act(() => resetData({ data: 'my previous data' }))
+    act(() => resetData({ data: 'my previous data' }))
     // should be back to initial state with previous data
     expect(state).toEqual({
       cacheHit: false,
@@ -207,7 +207,7 @@ describe('useClientRequest', () => {
       data: 'new data'
     })
 
-    await fetchData()
+    await act(fetchData)
 
     // it should keep the error when cached
     expect(state).toEqual({
@@ -241,7 +241,8 @@ describe('useClientRequest', () => {
       }
     })
 
-    await fetchData()
+    await act(fetchData)
+
     expect(state).toEqual({
       cacheHit: false,
       data: 'data',
@@ -257,10 +258,11 @@ describe('useClientRequest', () => {
     })
 
     mockClient.request.mockResolvedValueOnce(promise)
-    fetchData()
+    const fetchDataPromise = act(fetchData)
 
     expect(state).toEqual({ cacheHit: false, loading: true, data: 'data' })
     promiseResolve()
+    return fetchDataPromise
   })
 
   it('does not reset data when query or variables change if updateData is set', async () => {

--- a/packages/graphql-hooks/test/unit/useQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useQuery.test.js
@@ -364,49 +364,77 @@ describe('useQuery', () => {
     expect(mockClient2.ssrPromises[0]).resolves.toBe('data')
   })
 
-  describe('skip options', () => {
-    it('should skip query if `skip` is `true', () => {
+  describe('skip option', () => {
+    it('should skip query if `skip` is `true`', () => {
       const queryReqMock = jest.fn()
       useClientRequest.mockReturnValue([queryReqMock, mockState])
-      let skip = true
-      const { rerender } = renderHook(
-        () =>
+
+      renderHook(
+        ({ skip }) =>
           useQuery(TEST_QUERY, {
             skip
           }),
         {
-          wrapper: Wrapper
+          wrapper: Wrapper,
+          initialProps: {
+            skip: true
+          }
         }
       )
-      rerender()
 
       expect(queryReqMock).not.toHaveBeenCalled()
+    })
 
-      skip = false
-      rerender()
+    it('should query if `skip` value changes from `true` to `false`', () => {
+      const queryReqMock = jest.fn()
+      useClientRequest.mockReturnValue([queryReqMock, mockState])
+      const { rerender } = renderHook(
+        ({ skip }) =>
+          useQuery(TEST_QUERY, {
+            skip
+          }),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            skip: true
+          }
+        }
+      )
+
+      rerender({ skip: false })
 
       expect(queryReqMock).toHaveBeenCalled()
     })
 
-    it('should query if `skip` value changes', () => {
+    it('should not execute query again query if `skip` value changes from `false` to `true`', () => {
       const queryReqMock = jest.fn()
       useClientRequest.mockReturnValue([queryReqMock, mockState])
-      let skip = true
       const { rerender } = renderHook(
-        () =>
+        ({ skip }) =>
           useQuery(TEST_QUERY, {
             skip
           }),
         {
-          wrapper: Wrapper
+          wrapper: Wrapper,
+          initialProps: {
+            skip: false
+          }
         }
       )
-      rerender()
-      expect(queryReqMock).not.toHaveBeenCalled()
+      expect(queryReqMock).toHaveBeenCalledTimes(1)
 
-      skip = false
-      rerender()
-      expect(queryReqMock).toHaveBeenCalled()
+      rerender({ skip: true })
+
+      expect(queryReqMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not add query to ssrPromises when in ssrMode if `skip` is `true`', () => {
+      mockClient.ssrMode = true
+      mockQueryReq.mockResolvedValueOnce('data')
+      renderHook(() => useQuery(TEST_QUERY, { skip: true }), {
+        wrapper: Wrapper
+      })
+      expect(mockClient.ssrPromises).toHaveLength(0)
     })
   })
 })

--- a/packages/graphql-hooks/test/unit/useQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useQuery.test.js
@@ -46,7 +46,8 @@ describe('useQuery', () => {
   it('calls useClientRequest with query', () => {
     renderHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper })
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
-      useCache: true
+      useCache: true,
+      skip: false
     })
   })
 
@@ -56,7 +57,8 @@ describe('useQuery', () => {
         useQuery(TEST_QUERY, {
           useCache: false,
           extra: 'option',
-          client: mockClient2
+          client: mockClient2,
+          skip: true
         }),
       {
         wrapper: Wrapper
@@ -65,7 +67,8 @@ describe('useQuery', () => {
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       useCache: false,
       extra: 'option',
-      client: mockClient2
+      client: mockClient2,
+      skip: true
     })
   })
 
@@ -359,5 +362,51 @@ describe('useQuery', () => {
       wrapper: Wrapper
     })
     expect(mockClient2.ssrPromises[0]).resolves.toBe('data')
+  })
+
+  describe('skip options', () => {
+    it('should skip query if `skip` is `true', () => {
+      const queryReqMock = jest.fn()
+      useClientRequest.mockReturnValue([queryReqMock, mockState])
+      let skip = true
+      const { rerender } = renderHook(
+        () =>
+          useQuery(TEST_QUERY, {
+            skip
+          }),
+        {
+          wrapper: Wrapper
+        }
+      )
+      rerender()
+
+      expect(queryReqMock).not.toHaveBeenCalled()
+
+      skip = false
+      rerender()
+
+      expect(queryReqMock).toHaveBeenCalled()
+    })
+
+    it('should query if `skip` value changes', () => {
+      const queryReqMock = jest.fn()
+      useClientRequest.mockReturnValue([queryReqMock, mockState])
+      let skip = true
+      const { rerender } = renderHook(
+        () =>
+          useQuery(TEST_QUERY, {
+            skip
+          }),
+        {
+          wrapper: Wrapper
+        }
+      )
+      rerender()
+      expect(queryReqMock).not.toHaveBeenCalled()
+
+      skip = false
+      rerender()
+      expect(queryReqMock).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?

- Adds a  `skip` option to `useQuery` to offer the ability to skip a query conditionally
- The `skip` option is also watched for changes so the behavior of `useQuery` adapts to changing values of `skip`
- It also works with SSR
- It doesn't affect or change the `refetch` behavior in any way

### Related issues

Closes #154 

### Checklist

- [X] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [X] I have added or updated any relevant documentation
- [X] I have added or updated any relevant tests
