### PR TITLE
feat: throwErrors option in useQuery

### DIFF
--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
 import { GraphQLClient, ClientContext } from 'graphql-hooks'
 import memCache from 'graphql-hooks-memcache'
+
 import Posts from './components/Posts'
+import PostsWithErrorBoundary from './components/PostsWithErrorBoundary'
 
 const client = new GraphQLClient({
   cache: memCache(),
@@ -19,6 +21,7 @@ export default function App() {
       <span>Verify caching by hiding/showing the posts: </span>
       <button onClick={togglePosts}>{showPosts ? 'hide' : 'show'}</button>
       {showPosts && <Posts />}
+      {showPosts && <PostsWithErrorBoundary />}
     </ClientContext.Provider>
   )
 }

--- a/examples/create-react-app/src/components/CreatePost.js
+++ b/examples/create-react-app/src/components/CreatePost.js
@@ -1,5 +1,5 @@
 import { useMutation } from 'graphql-hooks'
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import React from 'react'
 import CreatePostForm from './CreatePostForm'
 
@@ -26,5 +26,5 @@ export default function CreatePost({ onSuccess }) {
 }
 
 CreatePost.propTypes = {
-  onSuccess: PropTypes.func
+  onSuccess: T.func
 }

--- a/examples/create-react-app/src/components/CreatePostForm.js
+++ b/examples/create-react-app/src/components/CreatePostForm.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types'
 import React, { useState } from 'react'
+import T from 'prop-types'
 
 export default function CreatePostForm({ loading, error, onSubmit }) {
   const [title, setTitle] = useState('')
@@ -36,7 +36,7 @@ export default function CreatePostForm({ loading, error, onSubmit }) {
 }
 
 CreatePostForm.propTypes = {
-  loading: PropTypes.bool,
-  error: PropTypes.bool,
-  onSubmit: PropTypes.func.isRequired
+  loading: T.bool,
+  error: T.bool,
+  onSubmit: T.func.isRequired
 }

--- a/examples/create-react-app/src/components/ErrorBoundary.js
+++ b/examples/create-react-app/src/components/ErrorBoundary.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import T from 'prop-types'
+
+function stringify(value) {
+  return JSON.stringify(
+    value,
+    (key, value) => {
+      if (key && typeof value === 'string') {
+        try {
+          return JSON.parse(value)
+        } catch (err) {
+          return value
+        }
+      }
+
+      return value
+    },
+    2
+  )
+}
+
+export default class ErrorBoundary extends React.Component {
+  static propTypes = {
+    children: T.node
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = { error: null, errorInfo: null }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error: error,
+      errorInfo: errorInfo
+    })
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div>
+          <div>Something went wrong.</div>
+          <details>
+            <summary>
+              <span>More details</span>
+            </summary>
+            <pre>{stringify(this.state.error)}</pre>
+            <pre>{this.state.errorInfo?.componentStack}</pre>
+          </details>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/examples/create-react-app/src/components/Posts.js
+++ b/examples/create-react-app/src/components/Posts.js
@@ -1,5 +1,5 @@
 import { useQuery } from 'graphql-hooks'
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import React from 'react'
 import CreatePost from './CreatePost'
 
@@ -43,13 +43,13 @@ function PostList({ loading, error, data }) {
 }
 
 PostList.propTypes = {
-  loading: PropTypes.bool,
-  error: PropTypes.shape({
-    fetchError: PropTypes.any,
-    httpError: PropTypes.any,
-    graphQLErrors: PropTypes.array
+  loading: T.bool,
+  error: T.shape({
+    fetchError: T.any,
+    httpError: T.any,
+    graphQLErrors: T.array
   }),
-  data: PropTypes.shape({
-    allPosts: PropTypes.array
+  data: T.shape({
+    allPosts: T.array
   })
 }

--- a/examples/create-react-app/src/components/PostsWithErrorBoundary.js
+++ b/examples/create-react-app/src/components/PostsWithErrorBoundary.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import { useQuery } from 'graphql-hooks'
+import T from 'prop-types'
+
+import ErrorBoundary from './ErrorBoundary'
+
+export const allPostsQuery = `
+  query {
+    allPosts {
+      id
+      title
+      url
+    }
+  }
+`
+
+export const errorAllPostsQuery = `
+  query {
+    allPosts {
+      id
+      title
+      url
+      boom
+    }
+  }
+`
+
+export default function PostsWithErrorBoundary() {
+  const [generateError, setGenerateError] = useState(false)
+  return (
+    <>
+      <h3>Posts with error boundary</h3>
+      <div>
+        <button onClick={() => setGenerateError(e => !e)}>
+          {generateError ? 'Do not generate error' : 'Generate error'}
+        </button>
+      </div>
+      <ErrorBoundary>
+        <PostList generateError={generateError} />
+      </ErrorBoundary>
+    </>
+  )
+}
+
+function PostList({ generateError }) {
+  const { loading, data } = useQuery(
+    generateError ? errorAllPostsQuery : allPostsQuery,
+    { throwErrors: true }
+  )
+
+  if (loading) return 'Loading...'
+  if (!data || !data.allPosts || !data.allPosts.length) return 'No posts'
+
+  return (
+    <ul>
+      {data.allPosts.map(post => (
+        <li key={post.id}>
+          <a href={post.url}>{post.title}</a>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+PostList.propTypes = {
+  generateError: T.bool
+}

--- a/examples/fastify-ssr/src/app/components/Hello.js
+++ b/examples/fastify-ssr/src/app/components/Hello.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import { useQuery } from 'graphql-hooks'
 
 const HELLO_QUERY = `
@@ -20,8 +20,8 @@ function HelloComponent({ user }) {
 }
 
 HelloComponent.propTypes = {
-  user: PropTypes.shape({
-    name: PropTypes.string
+  user: T.shape({
+    name: T.string
   })
 }
 

--- a/packages/graphql-hooks/src/useQuery.js
+++ b/packages/graphql-hooks/src/useQuery.js
@@ -5,7 +5,8 @@ import ClientContext from './ClientContext'
 
 const defaultOpts = {
   useCache: true,
-  skip: false
+  skip: false,
+  throwErrors: false
 }
 
 function useQuery(query, opts = {}) {
@@ -29,6 +30,7 @@ function useQuery(query, opts = {}) {
     }
     setCalledDuringSSR(true)
   }
+
   const stringifiedAllOpts = JSON.stringify(allOpts)
   React.useEffect(() => {
     if (allOpts.skip) {
@@ -37,6 +39,12 @@ function useQuery(query, opts = {}) {
 
     queryReq()
   }, [query, stringifiedAllOpts]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  React.useEffect(() => {
+    if (state.error && allOpts.throwErrors) {
+      throw state.error
+    }
+  }, [state.error, allOpts.throwErrors])
 
   return {
     ...state,

--- a/packages/graphql-hooks/test/integration/useQuery.test.js
+++ b/packages/graphql-hooks/test/integration/useQuery.test.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import memCache from 'graphql-hooks-memcache'
@@ -27,8 +27,8 @@ const TestComponent = ({ query = '{ hello }', options }) => {
   )
 }
 TestComponent.propTypes = {
-  options: PropTypes.object,
-  query: PropTypes.string
+  options: T.object,
+  query: T.string
 }
 
 describe('useQuery Integrations', () => {

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import { renderHook, act } from '@testing-library/react-hooks'
 import { useClientRequest, ClientContext } from '../../src'
 
@@ -11,7 +11,7 @@ const Wrapper = props => (
   </ClientContext.Provider>
 )
 Wrapper.propTypes = {
-  children: PropTypes.node
+  children: T.node
 }
 
 const TEST_QUERY = `query Test($limit: Int) {

--- a/packages/graphql-hooks/test/unit/useQuery.test.js
+++ b/packages/graphql-hooks/test/unit/useQuery.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import { renderHook } from '@testing-library/react-hooks'
 import { ClientContext, useQuery, useClientRequest } from '../../src'
 
@@ -11,7 +11,7 @@ const Wrapper = ({ children }) => (
   <ClientContext.Provider value={mockClient}>{children}</ClientContext.Provider>
 )
 Wrapper.propTypes = {
-  children: PropTypes.node
+  children: T.node
 }
 
 const TEST_QUERY = `query Test($limit: Int) {
@@ -47,7 +47,8 @@ describe('useQuery', () => {
     renderHook(() => useQuery(TEST_QUERY), { wrapper: Wrapper })
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       useCache: true,
-      skip: false
+      skip: false,
+      throwErrors: false
     })
   })
 
@@ -58,7 +59,8 @@ describe('useQuery', () => {
           useCache: false,
           extra: 'option',
           client: mockClient2,
-          skip: true
+          skip: true,
+          throwErrors: true
         }),
       {
         wrapper: Wrapper
@@ -68,7 +70,8 @@ describe('useQuery', () => {
       useCache: false,
       extra: 'option',
       client: mockClient2,
-      skip: true
+      skip: true,
+      throwErrors: true
     })
   })
 
@@ -435,6 +438,29 @@ describe('useQuery', () => {
         wrapper: Wrapper
       })
       expect(mockClient.ssrPromises).toHaveLength(0)
+    })
+  })
+
+  describe('throwErrors option', () => {
+    it('should throw error if `throwErrors` is `true`', () => {
+      const errorState = { error: new Error('boom') }
+
+      useClientRequest.mockReturnValue([jest.fn(), errorState])
+
+      const { result } = renderHook(
+        ({ throwErrors }) =>
+          useQuery(TEST_QUERY, {
+            throwErrors
+          }),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            throwErrors: true
+          }
+        }
+      )
+
+      expect(result.error).toBe(errorState.error)
     })
   })
 })

--- a/packages/graphql-hooks/test/unit/useSubscription.test.js
+++ b/packages/graphql-hooks/test/unit/useSubscription.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import T from 'prop-types'
 import { renderHook } from '@testing-library/react-hooks'
 import { ClientContext, useSubscription, GraphQLClient } from '../../src'
 
@@ -73,7 +73,7 @@ const Wrapper = ({ children }) => (
   <ClientContext.Provider value={mockClient}>{children}</ClientContext.Provider>
 )
 Wrapper.propTypes = {
-  children: PropTypes.node
+  children: T.node
 }
 
 const TEST_SUBSCRIPTION = `subscription TestSubscription($id: ID!) {


### PR DESCRIPTION
### What does this PR do?

Adds a `throwErrors` option to `useQuery` which throws errors instead of returning an `error` property in the resulting object.

This allows using Error Boundaries to intercept and display errors.

### Related issues

Resolves #324 

### How to test

See the updated create-react-app example application

### Checklist

- [X] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [X] I have added or updated any relevant documentation
- [X] I have added or updated any relevant tests
