### PR TITLE
Adds package-lock.json file in Dockerfile

### DIFF
--- a/examples/create-react-app/Dockerfile
+++ b/examples/create-react-app/Dockerfile
@@ -7,7 +7,7 @@ COPY package-lock.json ./
 COPY server ./server
 COPY public ./public
 
-RUN npm install
+RUN npm ci
 USER node
 
 CMD ["npm", "run", "start:server"]

--- a/examples/create-react-app/Dockerfile
+++ b/examples/create-react-app/Dockerfile
@@ -3,11 +3,11 @@ FROM node:14-alpine
 WORKDIR /service
 
 COPY package.json ./
+COPY package-lock.json ./
 COPY server ./server
 COPY public ./public
 
 RUN npm install
-
 USER node
 
 CMD ["npm", "run", "start:server"]


### PR DESCRIPTION
### What does this PR do?

Some actions failed in latest commits ([example](https://github.com/nearform/graphql-hooks/runs/3729760181?check_suite_focus=true))

Maybe some internal dependencies changed, but copying `package-lock.json` in `create-react-app` example Dockerfile fixed the issue.