### PR TITLE
fix: missing GraphQLClient type definitions (#677)

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -34,6 +34,8 @@ export class GraphQLClient {
     operation: Operation,
     options: UseClientRequestOptions<any, Variables>
   ): CacheKeyObject
+  getCache(cacheKey: CacheKeyObject): undefined | object
+  saveCache(cacheKey: CacheKeyObject, value: object): void
   getFetchOptions<Variables = object>(
     operation: Operation<Variables>,
     fetchOptionsOverrides?: object


### PR DESCRIPTION
### What does this PR do?

Adds missing TypeScript types for `GraphQLClient.getCache` and `GraphQLClient.saveCache`.

### Related issues

#677 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)

You have 1 lint warning, 7 files that require Prettier formatting, and 5 console errors emitted in your tests. None of which were caused by this PR.

- [x] I have added or updated any relevant documentation

N/A

- [x] I have added or updated any relevant tests

N/A
