### PR TITLE
fix: handle errors in useSubscription

### DIFF
--- a/packages/graphql-hooks/src/useSubscription.js
+++ b/packages/graphql-hooks/src/useSubscription.js
@@ -21,9 +21,8 @@ function useSubscription(options, callback) {
       next: result => {
         callbackRef.current(result)
       },
-      error: () => {
-        // TODO-db-210611 errors are important, why not handle them?
-        subscription.unsubscribe()
+      error: errors => {
+        callbackRef.current({ errors })
       },
       complete: () => {
         subscription.unsubscribe()

--- a/packages/graphql-hooks/test/unit/useSubscription.test.js
+++ b/packages/graphql-hooks/test/unit/useSubscription.test.js
@@ -43,7 +43,7 @@ class MockSubscriptionClient {
           if (error === null && result === null) {
             observer.complete()
           } else if (error) {
-            observer.error(error[0])
+            observer.error(error)
           } else {
             observer.next(result)
           }
@@ -139,14 +139,11 @@ describe('useSubscription', () => {
     })
   })
 
-  it('unsubscribes the subscription when subscription errs', done => {
-    const unsubscribe = jest.fn(() => {
-      done()
-    })
+  it('calls the update callback when subscription receives errors', () => {
+    const graphqlErrors = [{ message: 'error1' }, { message: 'error2' }]
     const subscriptionClient = new MockSubscriptionClient({
       type: 'ERROR',
-      data: [{ message: 'error' }],
-      unsubscribe
+      data: graphqlErrors
     })
 
     mockClient = new GraphQLClient({
@@ -161,7 +158,10 @@ describe('useSubscription', () => {
       }
     }
 
-    const callback = jest.fn()
+    const callback = ({ data, errors }) => {
+      expect(data).toEqual(undefined)
+      expect(errors).toEqual(graphqlErrors)
+    }
 
     renderHook(() => useSubscription(request, callback), {
       wrapper: Wrapper


### PR DESCRIPTION
### What does this PR do?

Instead of silently ignoring errors sent from the server, this PR makes `useSubscription` handle errors in the way documented (but previously unimplemented) in the readme:

https://github.com/nearform/graphql-hooks/blob/b7ff57d30fa9894162e7145bc5a5ad98e0561f0b/README.md#L427-L432

### Related issues

Fixes https://github.com/nearform/graphql-hooks/issues/682

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
