### PR TITLE
feat: refetch query when subscribed mutation executes

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ This is a custom hook that takes care of fetching your query and storing the res
     - `previousData`: Previous GraphQL query or `updateData` result
     - `data`: New GraphQL query result
   - `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
+  - `refetchAfterMutations`: Array of RefetchAferMutationsData - Mutations that will cause the refetch of the query
+    - `mutation`: String - The mutation string
+    - `filter`: Function (optional) - It receives mutation variables as parameter and blocks refetch if it returns false
 
 ### `useQuery` return value
 
@@ -573,6 +576,50 @@ export default function PostList() {
   )
 }
 ```
+
+## Refetch queries with mutations subscription
+
+We can have a query to automatically refetch when any mutation from a provided list execute.  
+In the following example we are refetching a list of posts for a given user.
+
+**Example**
+
+```jsx
+export const allPostsByUserIdQuery = `
+  query allPosts($userId: Int!) {
+    allPosts(userId: $userId) {
+      id
+      title
+      url
+    }
+  }
+`
+
+export const createPostMutation = `
+  mutation createPost($userId: Int!, $text: String!) {
+    createPost(userId: $userId, text: $text) {
+      id
+      title
+      url
+    }
+  }
+`
+
+const myUserId = 5
+
+useQuery(allPostsByUserIdQuery, {
+  variables: {
+    userId: myUserId
+  },
+  refetchAfterMutations: [
+    {
+      mutation: createPostMutation,
+      filter: (variables) => variables.userId === myUserId
+    }
+  ]
+})
+```
+
 
 ## File uploads
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This is a custom hook that takes care of fetching your query and storing the res
     - `data`: New GraphQL query result
   - `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
   - `refetchAfterMutations`: list of mutations that will trigger the query refetch. It can be either:
-    - String | String[] - The string of the mutation or an array of them
+    - String | String[] - The string containing the mutation's definition or an array of them
     - Object | Object[] with the following properties or an array of them
       - `mutation`: String - The mutation string
       - `filter`: Function (optional) - It receives mutation variables as parameter and blocks refetch if it returns false

--- a/README.md
+++ b/README.md
@@ -243,9 +243,11 @@ This is a custom hook that takes care of fetching your query and storing the res
     - `previousData`: Previous GraphQL query or `updateData` result
     - `data`: New GraphQL query result
   - `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
-  - `refetchAfterMutations`: Array of RefetchAferMutationsData - Mutations that will cause the refetch of the query
-    - `mutation`: String - The mutation string
-    - `filter`: Function (optional) - It receives mutation variables as parameter and blocks refetch if it returns false
+  - `refetchAfterMutations`: list of mutations that will trigger the query refetch. It can be either:
+    - String | String[] - The string of the mutation or an array of them
+    - Object | Object[] with the following properties or an array of them
+      - `mutation`: String - The mutation string
+      - `filter`: Function (optional) - It receives mutation variables as parameter and blocks refetch if it returns false
 
 ### `useQuery` return value
 

--- a/README.md
+++ b/README.md
@@ -243,11 +243,12 @@ This is a custom hook that takes care of fetching your query and storing the res
     - `previousData`: Previous GraphQL query or `updateData` result
     - `data`: New GraphQL query result
   - `client`: GraphQLClient - If a GraphQLClient is explicitly passed as an option, then it will be used instead of the client from the `ClientContext`.
-  - `refetchAfterMutations`: list of mutations that will trigger the query refetch. It can be either:
-    - String | String[] - The string containing the mutation's definition or an array of them
-    - Object | Object[] with the following properties or an array of them
+  - `refetchAfterMutations`: String | Object | (String | Object)[] - You can specify when a mutation should trigger query refetch.
+    - If it's a string, it's the mutation string
+    - If it's an object then it has properties mutation and filter
       - `mutation`: String - The mutation string
-      - `filter`: Function (optional) - It receives mutation variables as parameter and blocks refetch if it returns false
+      - `filter`: Function (optional) - It receives mutation's variables as parameter and blocks refetch if it returns false
+    - If it's an array, the elements can be of either type above
 
 ### `useQuery` return value
 

--- a/examples/create-react-app/src/components/CreatePost.js
+++ b/examples/create-react-app/src/components/CreatePost.js
@@ -1,30 +1,23 @@
 import { useMutation } from 'graphql-hooks'
-import T from 'prop-types'
 import React from 'react'
 import CreatePostForm from './CreatePostForm'
 
-const createPostMutation = `
-  mutation CreatePost($id: ID!, $title: String!, $url: String!) {
-    createPost(id: $id, title: $title, url: $url) {
+export const createPostMutation = `
+  mutation CreatePost($title: String!, $url: String!) {
+    createPost(title: $title, url: $url) {
       id
     }
   }
 `
 
-export default function CreatePost({ onSuccess }) {
+export default function CreatePost() {
   const [createPost, { loading, error }] = useMutation(createPostMutation)
 
   async function handleSubmit({ title, url }) {
-    const id = Math.floor(Math.random() * 1000000)
-    await createPost({ variables: { id, title, url } })
-    onSuccess && onSuccess()
+    await createPost({ variables: { title, url } })
   }
 
   return (
     <CreatePostForm loading={loading} error={error} onSubmit={handleSubmit} />
   )
-}
-
-CreatePost.propTypes = {
-  onSuccess: T.func
 }

--- a/examples/create-react-app/src/components/CreatePostForm.js
+++ b/examples/create-react-app/src/components/CreatePostForm.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
 import T from 'prop-types'
+import React, { useState } from 'react'
 
 export default function CreatePostForm({ loading, error, onSubmit }) {
   const [title, setTitle] = useState('')

--- a/examples/create-react-app/src/components/Posts.js
+++ b/examples/create-react-app/src/components/Posts.js
@@ -1,7 +1,7 @@
 import { useQuery } from 'graphql-hooks'
 import T from 'prop-types'
 import React from 'react'
-import CreatePost from './CreatePost'
+import CreatePost, { createPostMutation } from './CreatePost'
 
 export const allPostsQuery = `
   query {
@@ -14,7 +14,13 @@ export const allPostsQuery = `
 `
 
 export default function Posts() {
-  const { loading, data, error, refetch } = useQuery(allPostsQuery)
+  const { loading, data, error, refetch } = useQuery(allPostsQuery, {
+    refetchAfterMutations: [
+      {
+        mutation: createPostMutation
+      }
+    ]
+  })
 
   return (
     <>

--- a/examples/create-react-app/src/components/Posts.js
+++ b/examples/create-react-app/src/components/Posts.js
@@ -15,11 +15,7 @@ export const allPostsQuery = `
 
 export default function Posts() {
   const { loading, data, error, refetch } = useQuery(allPostsQuery, {
-    refetchAfterMutations: [
-      {
-        mutation: createPostMutation
-      }
-    ]
+    refetchAfterMutations: createPostMutation
   })
 
   return (

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -20,7 +20,7 @@ const client = new GraphQLClient({
 
 export const allPostsQuery = `
   query {
-    allPosts(orderBy: createdAt_DESC, first: 20) {
+    allPosts {
       id
       title
       url
@@ -46,7 +46,7 @@ const postQuery = `
   }
 `
 
-function AddPost({ onSuccess }: { onSuccess: () => void }) {
+function AddPost() {
   const [title, setTitle] = useState('')
   const [url, setUrl] = useState('')
   const [createPost, { loading, error }] = useMutation(createPostMutation)
@@ -54,7 +54,6 @@ function AddPost({ onSuccess }: { onSuccess: () => void }) {
   async function handleSubmit(e: any) {
     e.preventDefault()
     await createPost({ variables: { title, url } })
-    onSuccess && onSuccess()
   }
 
   return (
@@ -83,12 +82,18 @@ function AddPost({ onSuccess }: { onSuccess: () => void }) {
 }
 
 function Posts() {
-  const { loading, error, data, refetch } = useQuery(allPostsQuery)
+  const { loading, error, data, refetch } = useQuery(allPostsQuery, {
+    refetchAfterMutations: [
+      {
+        mutation: createPostMutation
+      }
+    ]
+  })
 
   return (
     <>
       <h2>Add post</h2>
-      <AddPost onSuccess={refetch} />
+      <AddPost />
       <h2>Posts</h2>
       <button onClick={() => refetch()}>Reload</button>
       <PostList loading={loading} error={error} data={data} />

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -83,11 +83,7 @@ function AddPost() {
 
 function Posts() {
   const { loading, error, data, refetch } = useQuery(allPostsQuery, {
-    refetchAfterMutations: [
-      {
-        mutation: createPostMutation
-      }
-    ]
+    refetchAfterMutations: createPostMutation
   })
 
   return (

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -196,7 +196,7 @@ export interface UseQueryOptions<ResponseData = any, Variables = object>
   extends UseClientRequestOptions<ResponseData, Variables> {
   ssr?: boolean
   skip?: boolean
-  refetchAfterMutations?: RefetchAferMutationsData
+  refetchAfterMutations?: RefetchAferMutationsData[]
 }
 
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -187,16 +187,20 @@ export interface UseClientRequestOptions<
   client?: GraphQLClient
 }
 
-type RefetchAferMutationsData = {
+export type RefetchAferMutationsData = {
   mutation: string
-  filter?: (variables: any) => boolean
+  filter?: (variables: object) => boolean
 }
 
 export interface UseQueryOptions<ResponseData = any, Variables = object>
   extends UseClientRequestOptions<ResponseData, Variables> {
   ssr?: boolean
   skip?: boolean
-  refetchAfterMutations?: RefetchAferMutationsData[]
+  refetchAfterMutations?:
+    | string
+    | string[]
+    | RefetchAferMutationsData
+    | RefetchAferMutationsData[]
 }
 
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -187,20 +187,22 @@ export interface UseClientRequestOptions<
   client?: GraphQLClient
 }
 
-export type RefetchAferMutationsData = {
+type RefetchAfterMutationItem = {
   mutation: string
   filter?: (variables: object) => boolean
 }
+
+export type RefetchAferMutationsData =
+  | string
+  | string[]
+  | RefetchAfterMutationItem
+  | RefetchAfterMutationItem[]
 
 export interface UseQueryOptions<ResponseData = any, Variables = object>
   extends UseClientRequestOptions<ResponseData, Variables> {
   ssr?: boolean
   skip?: boolean
-  refetchAfterMutations?:
-    | string
-    | string[]
-    | RefetchAferMutationsData
-    | RefetchAferMutationsData[]
+  refetchAfterMutations?: RefetchAferMutationsData
 }
 
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -189,7 +189,7 @@ export interface UseClientRequestOptions<
 
 type RefetchAferMutationsData = {
   mutation: string
-  filter?: (variables: any) => void
+  filter?: (variables: any) => boolean
 }
 
 export interface UseQueryOptions<ResponseData = any, Variables = object>

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -1,7 +1,7 @@
+import EventEmitter from 'events'
+import { Client } from 'graphql-ws'
 import * as React from 'react'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
-import { Client } from 'graphql-ws'
-
 // Exports
 
 export class GraphQLClient {
@@ -14,6 +14,7 @@ export class GraphQLClient {
   FormData?: any
   logErrors: boolean
   useGETForQueries: boolean
+  mutationsEmitter: EventEmitter
 
   subscriptionClient?: SubscriptionClient | Client
 
@@ -171,7 +172,10 @@ interface Result<ResponseData = any, TGraphQLError = object> {
   error?: APIError<TGraphQLError>
 }
 
-export interface UseClientRequestOptions<ResponseData = any, Variables = object> {
+export interface UseClientRequestOptions<
+  ResponseData = any,
+  Variables = object
+> {
   useCache?: boolean
   isMutation?: boolean
   isManual?: boolean
@@ -183,10 +187,16 @@ export interface UseClientRequestOptions<ResponseData = any, Variables = object>
   client?: GraphQLClient
 }
 
+type RefetchAferMutationsData = {
+  mutation: string
+  filter?: (variables: any) => void
+}
+
 export interface UseQueryOptions<ResponseData = any, Variables = object>
   extends UseClientRequestOptions<ResponseData, Variables> {
   ssr?: boolean
   skip?: boolean
+  refetchAfterMutations?: RefetchAferMutationsData
 }
 
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {

--- a/packages/graphql-hooks/package-lock.json
+++ b/packages/graphql-hooks/package-lock.json
@@ -413,6 +413,11 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
       "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "extract-files": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
@@ -458,6 +463,21 @@
         }
       }
     },
+    "graphql-hooks-memcache": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-hooks-memcache/-/graphql-hooks-memcache-2.2.1.tgz",
+      "integrity": "sha512-LFggoX5k5n3Dzsj/muGffbrdtIaYccOLRCA4HHBncCf0MQnhJvrlrw2Jy+Ph8u5OJ2ZRuKv8aFbh5P0/4xnHsA==",
+      "dev": true,
+      "requires": {
+        "tiny-lru": "^7.0.0"
+      }
+    },
+    "graphql-hooks-ssr": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-hooks-ssr/-/graphql-hooks-ssr-2.2.1.tgz",
+      "integrity": "sha512-+caFfqoCOLpMKrPZh9uBqqryX+bhpXTZ1mX9hqwfdvC7qTy3hgDrrFWJw5x131kXYJK0TZZkmojnnJoHMpKWVw==",
+      "dev": true
+    },
     "graphql-ws": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.3.0.tgz",
@@ -495,6 +515,48 @@
           "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
           "dev": true
         }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       }
     },
     "react-test-renderer": {
@@ -576,6 +638,16 @@
         }
       }
     },
+    "scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "subscriptions-transport-ws": {
       "version": "0.9.19",
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
@@ -620,6 +692,12 @@
           "dev": true
         }
       }
+    },
+    "tiny-lru": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
+      "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==",
+      "dev": true
     }
   }
 }

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-hooks",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "Graphql Hooks",
   "main": "lib/graphql-hooks.js",
   "module": "es/graphql-hooks.js",

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-hooks",
-  "version": "5.5.0",
+  "version": "5.4.1",
   "description": "Graphql Hooks",
   "main": "lib/graphql-hooks.js",
   "module": "es/graphql-hooks.js",

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "dequal": "^2.0.0",
+    "events": "^3.3.0",
     "extract-files": "^11.0.0"
   },
   "devDependencies": {

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -1,7 +1,7 @@
+import EventEmitter from 'events'
 import { extractFiles } from 'extract-files'
-
-import isExtractableFileEnhanced from './isExtractableFileEnhanced'
 import canUseDOM from './canUseDOM'
+import isExtractableFileEnhanced from './isExtractableFileEnhanced'
 
 class GraphQLClient {
   constructor(config = {}) {
@@ -39,6 +39,7 @@ class GraphQLClient {
     this.onError = config.onError
     this.useGETForQueries = config.useGETForQueries === true
     this.subscriptionClient = config.subscriptionClient
+    this.mutationsEmitter = new EventEmitter()
   }
 
   setHeader(key, value) {

--- a/packages/graphql-hooks/src/createRefetchMutationsMap.js
+++ b/packages/graphql-hooks/src/createRefetchMutationsMap.js
@@ -2,7 +2,7 @@
  * Checks values of refetchAfterMutations public option and maps them to an object
  * @typedef {import('../index').RefetchAferMutationsData} RefetchAferMutationsData
  *
- * @param {string | string[] | RefetchAferMutationsData | RefetchAferMutationsData[]} refetchAfterMutations
+ * @param {RefetchAferMutationsData} refetchAfterMutations
  * @returns {object}
  */
 export default function createRefetchMutationsMap(refetchAfterMutations) {

--- a/packages/graphql-hooks/src/createRefetchMutationsMap.js
+++ b/packages/graphql-hooks/src/createRefetchMutationsMap.js
@@ -1,0 +1,31 @@
+/**
+ * Checks values of refetchAfterMutations public option and maps them to an object
+ * @typedef {import('../index').RefetchAferMutationsData} RefetchAferMutationsData
+ *
+ * @param {string | string[] | RefetchAferMutationsData | RefetchAferMutationsData[]} refetchAfterMutations
+ * @returns {object}
+ */
+export default function createRefetchMutationsMap(refetchAfterMutations) {
+  const mutations = Array.isArray(refetchAfterMutations)
+    ? refetchAfterMutations
+    : [refetchAfterMutations]
+  const result = {}
+
+  mutations.forEach(mutationInfo => {
+    if (mutationInfo == null) return
+
+    const paramType = typeof mutationInfo
+
+    if (paramType === 'string') {
+      result[mutationInfo] = {}
+    }
+
+    if (paramType === 'object') {
+      const { filter, mutation } = mutationInfo
+
+      result[mutation] = { filter }
+    }
+  })
+
+  return result
+}

--- a/packages/graphql-hooks/src/createRefetchMutationsMap.js
+++ b/packages/graphql-hooks/src/createRefetchMutationsMap.js
@@ -18,9 +18,7 @@ export default function createRefetchMutationsMap(refetchAfterMutations) {
 
     if (paramType === 'string') {
       result[mutationInfo] = {}
-    }
-
-    if (paramType === 'object') {
+    } else if (paramType === 'object') {
       const { filter, mutation } = mutationInfo
 
       result[mutation] = { filter }

--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -1,5 +1,5 @@
-import React from 'react'
 import { dequal } from 'dequal'
+import React from 'react'
 import ClientContext from './ClientContext'
 
 const actionTypes = {
@@ -195,6 +195,14 @@ function useClientRequest(query, initialOpts = {}) {
           dispatch({
             type: actionTypes.REQUEST_RESULT,
             updateData: revisedOpts.updateData,
+            result: actionResult
+          })
+        }
+
+        if (initialOpts.isMutation) {
+          client.mutationsEmitter.emit(query, {
+            ...revisedOperation,
+            mutation: query,
             result: actionResult
           })
         }

--- a/packages/graphql-hooks/test/unit/createRefetchMutationsMap.test.js
+++ b/packages/graphql-hooks/test/unit/createRefetchMutationsMap.test.js
@@ -1,0 +1,47 @@
+import createRefetchMutationsMap from '../../src/createRefetchMutationsMap'
+
+describe('createRefetchMutationsMap', () => {
+  it('accepts a string parameter', () => {
+    const result = createRefetchMutationsMap('my-mutation')
+
+    expect(result).toEqual({
+      'my-mutation': {}
+    })
+  })
+
+  it('accepts an object parameter', () => {
+    const result = createRefetchMutationsMap({ mutation: 'my-mutation' })
+
+    expect(result).toEqual({
+      'my-mutation': {}
+    })
+  })
+
+  it('accepts an array parameter', () => {
+    const filter = () => {}
+    const result = createRefetchMutationsMap([
+      { mutation: 'my-mutation' },
+      'my-mutation-2',
+      { mutation: 'my-mutation-3', filter }
+    ])
+
+    expect(result).toEqual({
+      'my-mutation': {},
+      'my-mutation-2': {},
+      'my-mutation-3': { filter }
+    })
+  })
+
+  it('filters out invalid parameters', () => {
+    const result = createRefetchMutationsMap([
+      { mutation: 'my-mutation' },
+      2,
+      null,
+      undefined
+    ])
+
+    expect(result).toEqual({
+      'my-mutation': {}
+    })
+  })
+})

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -20,9 +20,18 @@ const TEST_QUERY = `query Test($limit: Int) {
   }
 }`
 
+const TEST_MUTATION = `mutation UpdateUser($userId: Number!, $name: String!) {
+  updateUser(userId: $userId, name: $name) {
+    name
+  }
+}`
+
 describe('useClientRequest', () => {
   beforeEach(() => {
     mockClient = {
+      mutationsEmitter: {
+        emit: jest.fn()
+      },
       getCacheKey: jest.fn().mockReturnValue('cacheKey'),
       getCache: jest.fn(),
       saveCache: jest.fn(),
@@ -45,6 +54,9 @@ describe('useClientRequest', () => {
 
   it('uses a passed client', async () => {
     const mockClient2 = {
+      mutationsEmitter: {
+        emit: jest.fn()
+      },
       getCacheKey: jest.fn().mockReturnValue('cacheKey'),
       getCache: jest.fn(),
       saveCache: jest.fn(),
@@ -793,6 +805,48 @@ describe('useClientRequest', () => {
           { ...options, fetchOptionsOverrides: { method: 'GET' } }
         )
       })
+    })
+
+    it('emits an event when a mutation returns its result', async () => {
+      const mockClient = {
+        mutationsEmitter: {
+          emit: jest.fn()
+        },
+        getCacheKey: jest.fn().mockReturnValue('cacheKey'),
+        getCache: jest.fn(),
+        saveCache: jest.fn(),
+        cache: {
+          get: jest.fn(),
+          set: jest.fn()
+        },
+        request: jest.fn().mockResolvedValue({ data: 'data' })
+      }
+      const options = {
+        isMutation: true,
+        client: mockClient,
+        variables: {
+          userId: 2,
+          name: 'test'
+        }
+      }
+      let fetchData
+
+      renderHook(
+        () => ([fetchData] = useClientRequest(TEST_MUTATION, options)),
+        {
+          wrapper: Wrapper
+        }
+      )
+
+      await act(fetchData)
+
+      expect(mockClient.mutationsEmitter.emit).toHaveBeenCalledWith(
+        TEST_MUTATION,
+        expect.objectContaining({
+          variables: options.variables,
+          mutation: TEST_MUTATION
+        })
+      )
     })
 
     describe('persisted', () => {


### PR DESCRIPTION
### Refetch a query when a dependant mutation executes

I read the following issues:

> "Add ability to update the cache after a mutation #52"

> Refetch queries with mutations subscription #74

They contain a proposal by @bmullan91 and jgoux that I liked, the n.3 about **refetchAfterMutations**.

Meaning that when using `useQuery` we can subscribe to a list of mutations that make the entire query refetch.
It also allows a `filter` property with a function that allows refetch only when it evaluates true.

Query below executes again when `UPDATE_USER_MUTATION` executes and contains `userId === 1` in its variables.

```js
useQuery(TEST_QUERY, {
  refetchAfterMutations: [
    {
      mutation: UPDATE_USER_MUTATION,
      filter: ({ userId }) => userId === 1
    }
  ]
})
```

The above is achieved by adding an EventEmitter ([new events dependency](https://www.npmjs.com/package/events)) property to the GraphQLClient class.

While the issue also mentions the manual manipulation of the cache when a mutation happens to avoid roundtrips, I believe that this implementation stays relevant because it's easier to use and flexible.

It's my first contribution to the project and I am afraid that I am missing out something important: looking forward to hearing your thoughts :)

### Related issues

- https://github.com/nearform/graphql-hooks/issues/52
- https://github.com/nearform/graphql-hooks/issues/74

### For reviewers

The first commit in this work contains the implementation which touches 8 files.  
The next commits is me updating the project to Node 16, to fix Netlify build that relies already on it.
If this work wasn't needed I'll take them out.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
