### PR TITLE
fix: memcache options type missing debug property

### DIFF
--- a/packages/graphql-hooks-memcache/index.d.ts
+++ b/packages/graphql-hooks-memcache/index.d.ts
@@ -4,6 +4,7 @@ declare function MemCacheFunction(options?: {
   size?: number
   ttl?: number
   initialState?: object
+  debug?: boolean
 }): MemCache
 
 interface MemCache {


### PR DESCRIPTION
### What does this PR do?

Adds missing `debug` property to memcache options type

### Related issues

<!-- Link to any related issues here -->

### Checklist

- [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
