### PR TITLE
docs: Removed spectrum badge and added Community section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ const client = new GraphQLClient({
 
 ## Community
 
-We now use GitHub Discussions for our community. To join, click <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" class="octicon octicon-comment-discussion" aria-label="The discussion icon" role="img"><path fill-rule="evenodd" d="M1.5 2.75a.25.25 0 01.25-.25h8.5a.25.25 0 01.25.25v5.5a.25.25 0 01-.25.25h-3.5a.75.75 0 00-.53.22L3.5 11.44V9.25a.75.75 0 00-.75-.75h-1a.25.25 0 01-.25-.25v-5.5zM1.75 1A1.75 1.75 0 000 2.75v5.5C0 9.216.784 10 1.75 10H2v1.543a1.457 1.457 0 002.487 1.03L7.061 10h3.189A1.75 1.75 0 0012 8.25v-5.5A1.75 1.75 0 0010.25 1h-8.5zM14.5 4.75a.25.25 0 00-.25-.25h-.5a.75.75 0 110-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0114.25 12H14v1.543a1.457 1.457 0 01-2.487 1.03L9.22 12.28a.75.75 0 111.06-1.06l2.22 2.22v-2.19a.75.75 0 01.75-.75h1a.25.25 0 00.25-.25v-5.5z"></path></svg> Discussions.
+We now use GitHub Discussions for our community. To join, click on "Discussions".
 If you want to see the old community posts (on Spectrum) you can access them [here](https://spectrum.chat/graphql-hooks).
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ const client = new GraphQLClient({
 
 ## Community
 
-We now use GitHub Discussions for our community. To join, click on "Discussions".
+We now use GitHub Discussions for our community. To join, click on ["Discussions"](https://github.com/nearform/graphql-hooks/discussions).
 If you want to see the old community posts (on Spectrum) you can access them [here](https://spectrum.chat/graphql-hooks).
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # graphql-hooks
 
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/graphql-hooks)
 [![ci](https://github.com/nearform/graphql-hooks/workflows/ci/badge.svg)](https://github.com/nearform/graphql-hooks/actions?query=workflow%3Aci)
 [![Coverage Status](https://coveralls.io/repos/github/nearform/graphql-hooks/badge.svg?branch=master)](https://coveralls.io/github/nearform/graphql-hooks?branch=master)
 [![bundlephobia](https://img.shields.io/bundlephobia/minzip/graphql-hooks.svg?style=flat&label=size)](https://bundlephobia.com/result?p=graphql-hooks)
@@ -990,6 +989,10 @@ const client = new GraphQLClient({
 })
 ```
 
+## Community
+
+We now use GitHub Discussions for our community. To join, click <svg version="1.1" width="16" height="16" viewBox="0 0 16 16" class="octicon octicon-comment-discussion" aria-label="The discussion icon" role="img"><path fill-rule="evenodd" d="M1.5 2.75a.25.25 0 01.25-.25h8.5a.25.25 0 01.25.25v5.5a.25.25 0 01-.25.25h-3.5a.75.75 0 00-.53.22L3.5 11.44V9.25a.75.75 0 00-.75-.75h-1a.25.25 0 01-.25-.25v-5.5zM1.75 1A1.75 1.75 0 000 2.75v5.5C0 9.216.784 10 1.75 10H2v1.543a1.457 1.457 0 002.487 1.03L7.061 10h3.189A1.75 1.75 0 0012 8.25v-5.5A1.75 1.75 0 0010.25 1h-8.5zM14.5 4.75a.25.25 0 00-.25-.25h-.5a.75.75 0 110-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0114.25 12H14v1.543a1.457 1.457 0 01-2.487 1.03L9.22 12.28a.75.75 0 111.06-1.06l2.22 2.22v-2.19a.75.75 0 01.75-.75h1a.25.25 0 00.25-.25v-5.5z"></path></svg> Discussions.
+If you want to see the old community posts (on Spectrum) you can access them [here](https://spectrum.chat/graphql-hooks).
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ const client = new GraphQLClient({
 
 ## Community
 
-We now use GitHub Discussions for our community. To join, click on ["Discussions"](https://github.com/nearform/graphql-hooks/discussions).
+We now use GitHub Discussions for our community. To join, click on ["Discussions"](https://github.com/nearform/graphql-hooks/discussions). We encourage you to start a new discussion, share some ideas or ask questions from the community.
 If you want to see the old community posts (on Spectrum) you can access them [here](https://spectrum.chat/graphql-hooks).
 ## Contributors
 


### PR DESCRIPTION
### What does this PR do?

Removes Spectrum community badge and adds a new "Community" section in the README. 

~**Important**: **_Before merging this PR, GitHub Discussions need to be enabled in the Settings. Here is how to do it: https://docs.github.com/en/discussions/quickstart#enabling-github-discussions-on-your-repository
Only users with "write access" to this repository can do this._**~

Update: GitHub Discussions are now enabled.

### Related issues

Closes #719 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
