### PR TITLE
feat: added response proxy

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -312,6 +312,16 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "zanettin",
+      "name": "Roman Zanettin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3241476?v=4",
+      "profile": "https://github.com/zanettin",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/workflows/create-react-app-server.yml
+++ b/.github/workflows/create-react-app-server.yml
@@ -18,10 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - uses: google-github-actions/setup-gcloud@v0.2.1
+      - uses: google-github-actions/auth@v0.4.1
         with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - uses: google-github-actions/setup-gcloud@v0.3
 
       - working-directory: ./examples/create-react-app
         run: |-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please take a second to read over this before opening an issue. Providing complete information upfront will help us address any issue (and ship new features!) faster.
 
-We greatly appreciate bug fixes, documentation improvements and new features, however when contributing a new major feature, it is a good idea to idea to first open an issue, to make sure the feature it fits with the goal of the project, so we don't waste your or our time.
+We greatly appreciate bug fixes, documentation improvements and new features, however when contributing a new major feature, it is a good idea to first open an issue, to make sure the feature it fits with the goal of the project, so we don't waste your or our time.
 
 ## Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ const client = new GraphQLClient(config)
 - `request(operation, options)`: Make a request to your GraphQL server; returning a Promise
   - `operation`: Object with `query`, `variables` and `operationName`
 - `options.fetchOptionsOverrides`: Object containing additional fetch options to be added to the default ones passed to `new GraphQLClient(config)`
-- `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are appended to the `request` response under the `responseReducer` key. Example usage: `{responseReducer: (response) => ({myKey: response.headers.get('content-length)})`
+- `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are merged to the `request` response under the `data` key. Example usage: `{responseReducer: (data, response) => ({...data, myKey: response.headers.get('content-length)})`
 
 ## `ClientContext`
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ const client = new GraphQLClient(config)
 - `request(operation, options)`: Make a request to your GraphQL server; returning a Promise
   - `operation`: Object with `query`, `variables` and `operationName`
 - `options.fetchOptionsOverrides`: Object containing additional fetch options to be added to the default ones passed to `new GraphQLClient(config)`
+- `options.responseProxy`: Key-Value pairs to map parts of the original Fetch API response into the return value. Example for header forwarding would look like `{responseProxy: {header: resp => resp.headers}}`. Accessable is everything which the chosen Fetch implementation supports on the `Response` object.
 
 ## `ClientContext`
 
@@ -615,12 +616,11 @@ useQuery(allPostsByUserIdQuery, {
   refetchAfterMutations: [
     {
       mutation: createPostMutation,
-      filter: (variables) => variables.userId === myUserId
+      filter: variables => variables.userId === myUserId
     }
   ]
 })
 ```
-
 
 ## File uploads
 
@@ -993,6 +993,7 @@ const client = new GraphQLClient({
 
 We now use GitHub Discussions for our community. To join, click on ["Discussions"](https://github.com/nearform/graphql-hooks/discussions). We encourage you to start a new discussion, share some ideas or ask questions from the community.
 If you want to see the old community posts (on Spectrum) you can access them [here](https://spectrum.chat/graphql-hooks).
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ const client = new GraphQLClient(config)
 - `request(operation, options)`: Make a request to your GraphQL server; returning a Promise
   - `operation`: Object with `query`, `variables` and `operationName`
 - `options.fetchOptionsOverrides`: Object containing additional fetch options to be added to the default ones passed to `new GraphQLClient(config)`
-- `options.responseProxy`: Key-Value pairs to map parts of the original Fetch API response into the return value. Example for header forwarding would look like `{responseProxy: {header: resp => resp.headers}}`. Accessable is everything which the chosen Fetch implementation supports on the `Response` object.
+- `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are appended to the `request` response under the `responseReducer` key. Example usage: `{responseReducer: (response) => ({myKey: response.header.get('content-length)})`
 
 ## `ClientContext`
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ const client = new GraphQLClient(config)
 - `request(operation, options)`: Make a request to your GraphQL server; returning a Promise
   - `operation`: Object with `query`, `variables` and `operationName`
 - `options.fetchOptionsOverrides`: Object containing additional fetch options to be added to the default ones passed to `new GraphQLClient(config)`
-- `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are appended to the `request` response under the `responseReducer` key. Example usage: `{responseReducer: (response) => ({myKey: response.header.get('content-length)})`
+- `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are appended to the `request` response under the `responseReducer` key. Example usage: `{responseReducer: (response) => ({myKey: response.headers.get('content-length)})`
 
 ## `ClientContext`
 

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -185,6 +185,7 @@ export interface UseClientRequestOptions<
   fetchOptionsOverrides?: object
   updateData?(previousData: ResponseData, data: ResponseData): any
   client?: GraphQLClient
+  responseReducer(response: object): object
 }
 
 type RefetchAfterMutationItem = {

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -185,7 +185,7 @@ export interface UseClientRequestOptions<
   fetchOptionsOverrides?: object
   updateData?(previousData: ResponseData, data: ResponseData): any
   client?: GraphQLClient
-  responseReducer?(response: object): object
+  responseReducer?(data:object, response: object): object
 }
 
 type RefetchAfterMutationItem = {

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -185,7 +185,7 @@ export interface UseClientRequestOptions<
   fetchOptionsOverrides?: object
   updateData?(previousData: ResponseData, data: ResponseData): any
   client?: GraphQLClient
-  responseReducer(response: object): object
+  responseReducer?(response: object): object
 }
 
 type RefetchAfterMutationItem = {

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -90,20 +90,14 @@ class GraphQLClient {
   }
   /* eslint-enable no-console */
 
-  generateResult({
-    fetchError,
-    httpError,
-    graphQLErrors,
-    data,
-    responseReducer
-  }) {
+  generateResult({ fetchError, httpError, graphQLErrors, data }) {
     const errorFound = !!(
       (graphQLErrors && graphQLErrors.length > 0) ||
       fetchError ||
       httpError
     )
     return !errorFound
-      ? Object.assign({ data }, !!responseReducer && { responseReducer })
+      ? { data }
       : { data, error: { fetchError, httpError, graphQLErrors } }
   }
 
@@ -231,11 +225,11 @@ class GraphQLClient {
           return response.json().then(({ errors, data }) => {
             return this.generateResult({
               graphQLErrors: errors,
-              data,
-              responseReducer:
+              data:
+                // enrich data with responseReducer if defined
                 (typeof options.responseReducer === 'function' &&
-                  options.responseReducer(response)) ||
-                null
+                  options.responseReducer(data, response)) ||
+                data
             })
           })
         }

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -244,8 +244,6 @@ class GraphQLClient {
                     : options.responseProxy[key](response)
               }
             })
-
-            console.log(responseProxy)
           }
 
           return response.json().then(({ errors, data }) => {

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -95,7 +95,7 @@ class GraphQLClient {
     httpError,
     graphQLErrors,
     data,
-    responseReducer = null
+    responseReducer
   }) {
     const errorFound = !!(
       (graphQLErrors && graphQLErrors.length > 0) ||

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -583,7 +583,7 @@ describe('GraphQLClient', () => {
       expect(actual).toMatchObject(expected)
     })
 
-    it('will use responseProxy option implementation', async () => {
+    it('will use responseReducer option implementation', async () => {
       const data = 'data!',
         status = 200,
         statusText = 'OK',
@@ -597,25 +597,22 @@ describe('GraphQLClient', () => {
         statusText,
         headers
       })
-      const {
-        data: _data,
-        headers: _headers,
-        status: _status,
-        statusText: _statusText
-      } = await client.request(
+      const { data: _data, responseReducer } = await client.request(
         { query: TEST_QUERY },
         {
-          responseProxy: {
-            headers: response => response.headers,
-            status: response => response.status,
-            statusText: response => response.statusText
-          }
+          responseReducer: response => ({
+            cacheTags: response.headers.get('x-cache-tags'),
+            contentType: response.headers.get('content-type'),
+            status: response.status,
+            statusText: response.statusText
+          })
         }
       )
-      expect(_headers).toEqual(headers)
       expect(_data).toBe(data)
-      expect(_status).toBe(status)
-      expect(_statusText).toBe(statusText)
+      expect(responseReducer.status).toBe(status)
+      expect(responseReducer.statusText).toBe(statusText)
+      expect(responseReducer.cacheTags).toEqual(headers['x-cache-tags'])
+      expect(responseReducer.contentType).toEqual(headers['content-type'])
     })
 
     describe('GET Support', () => {

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -584,7 +584,7 @@ describe('GraphQLClient', () => {
     })
 
     it('will use responseReducer option implementation', async () => {
-      const data = 'data!',
+      const data = { some: 'data' },
         status = 200,
         statusText = 'OK',
         headers = {
@@ -597,10 +597,11 @@ describe('GraphQLClient', () => {
         statusText,
         headers
       })
-      const { data: _data, responseReducer } = await client.request(
+      const { data: _data } = await client.request(
         { query: TEST_QUERY },
         {
-          responseReducer: response => ({
+          responseReducer: (fetchedData, response) => ({
+            ...fetchedData,
             cacheTags: response.headers.get('x-cache-tags'),
             contentType: response.headers.get('content-type'),
             status: response.status,
@@ -608,11 +609,11 @@ describe('GraphQLClient', () => {
           })
         }
       )
-      expect(_data).toBe(data)
-      expect(responseReducer.status).toBe(status)
-      expect(responseReducer.statusText).toBe(statusText)
-      expect(responseReducer.cacheTags).toEqual(headers['x-cache-tags'])
-      expect(responseReducer.contentType).toEqual(headers['content-type'])
+      expect(_data.some).toBe(data.some)
+      expect(_data.status).toBe(status)
+      expect(_data.statusText).toBe(statusText)
+      expect(_data.cacheTags).toEqual(headers['x-cache-tags'])
+      expect(_data.contentType).toEqual(headers['content-type'])
     })
 
     describe('GET Support', () => {


### PR DESCRIPTION
### What does this PR do?
It's an implementation **proposal** for this issue https://github.com/nearform/graphql-hooks/issues/729. The goal is to give the user access to all properties on the Fetch API `Response` object. In our case we're interested in the headers to get the assigned cache keys on SSR rendered apps. With this approach, the user can define in which properties he/she is interested and just those will be returned under the defined key on the response of `client.request()` calls.

### Related issues
https://github.com/nearform/graphql-hooks/issues/729

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
