### PR TITLE
fix: corrects the fetch existence check

### DIFF
--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -14,7 +14,11 @@ class GraphQLClient {
       throw new Error('GraphQLClient: config.fetch must be a function')
     }
 
-    if ((canUseDOM() || config.ssrMode) && !config.fetch && !fetch) {
+    if (
+      (canUseDOM() || config.ssrMode) &&
+      !config.fetch &&
+      typeof fetch !== 'function'
+    ) {
       throw new Error(
         'GraphQLClient: fetch must be polyfilled or passed in new GraphQLClient({ fetch })'
       )

--- a/packages/graphql-hooks/test/unit/GraphQLClient.test.js
+++ b/packages/graphql-hooks/test/unit/GraphQLClient.test.js
@@ -38,7 +38,7 @@ describe('GraphQLClient', () => {
       const oldFetch = global.fetch
       try {
         expect(window.document.createElement).toBeTruthy()
-        global.fetch = null
+        delete global.fetch
         expect(() => {
           new GraphQLClient({
             ...validConfig,
@@ -55,7 +55,7 @@ describe('GraphQLClient', () => {
     it('throws if fetch is not present or polyfilled when ssrMode is true', () => {
       const oldFetch = global.fetch
       try {
-        global.fetch = null
+        delete global.fetch
         expect(() => {
           new GraphQLClient({
             ...validConfig,
@@ -74,7 +74,7 @@ describe('GraphQLClient', () => {
       const oldFetch = global.fetch
       const oldWindow = global.window
       try {
-        global.fetch = null
+        delete global.fetch
         expect(global.window.document.createElement).toBeTruthy()
         delete global.window
         const client = new GraphQLClient({


### PR DESCRIPTION
As for now, when `fetch` is not defined what you get is an `fetch is not defined` error

By reading the tests the intention was to provide a more clear error `GraphQLClient: fetch must be polyfilled or passed in new GraphQLClient({ fetch })`

This was not happening because there was an error in the existence check

With this change the expected behavoir should be restored