### PR TITLE
feat: subscriptionClient accepts now a factory function as value

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ const client = new GraphQLClient(config)
 - `url` (**Required**): The url to your GraphQL server
 - `ssrMode`: Boolean - set to `true` when using on the server for server-side rendering; defaults to `false`
 - `useGETForQueries`: Boolean - set to `true` to use HTTP GET method for all queries; defaults to false. See [HTTP Get Support](#HTTP-Get-support) for more info
-- `subscriptionClient`: An instance of `SubscriptionClient` from [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) or `Client` from [graphql-ws](https://github.com/enisdenjo/graphql-ws)
+- `subscriptionClient`: An instance of `SubscriptionClient` from [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) or `Client` from [graphql-ws](https://github.com/enisdenjo/graphql-ws). A factory function can also be passed in order to avoid the creation of the client in ssr environments.
 - `cache` (**Required** if `ssrMode` is `true`, otherwise optional): Object with the following methods:
   - `cache.get(key)`
   - `cache.set(key, data)`
@@ -400,11 +400,11 @@ import { createClient } from 'graphql-ws'
 
 const client = new GraphQLClient({
   url: 'http://localhost:8000/graphql',
-  subscriptionClient: new SubscriptionClient('ws://localhost:8000/graphql', {
+  subscriptionClient: () => new SubscriptionClient('ws://localhost:8000/graphql', {
     /* additional config options */
   }),
   // or
-  subscriptionClient: createClient({
+  subscriptionClient: () => createClient({
     url: 'ws://localhost:8000/graphql'
     /* additional config options */
   })

--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -16,7 +16,10 @@ export class GraphQLClient {
   useGETForQueries: boolean
   mutationsEmitter: EventEmitter
 
-  subscriptionClient?: SubscriptionClient | Client
+  subscriptionClient?:
+    | SubscriptionClient
+    | Client
+    | (() => SubscriptionClient | Client)
 
   private onError(): any
   private fetch(): Promise<any>
@@ -124,7 +127,10 @@ interface ClientOptions {
   headers?: Headers
   ssrMode?: boolean
   useGETForQueries?: boolean
-  subscriptionClient?: SubscriptionClient | Client
+  subscriptionClient?:
+    | SubscriptionClient
+    | Client
+    | (() => SubscriptionClient | Client)
   fetch?(url: string, options?: object): Promise<object>
   fetchOptions?: object
   FormData?: any
@@ -185,7 +191,7 @@ export interface UseClientRequestOptions<
   fetchOptionsOverrides?: object
   updateData?(previousData: ResponseData, data: ResponseData): any
   client?: GraphQLClient
-  responseReducer?(data:object, response: object): object
+  responseReducer?(data: object, response: object): object
 }
 
 type RefetchAfterMutationItem = {

--- a/packages/graphql-hooks/src/GraphQLClient.js
+++ b/packages/graphql-hooks/src/GraphQLClient.js
@@ -254,6 +254,10 @@ class GraphQLClient {
   }
 
   createSubscription(operation) {
+    if (typeof this.subscriptionClient === 'function') {
+      this.subscriptionClient = this.subscriptionClient()
+    }
+
     if (!this.subscriptionClient) {
       throw new Error('No SubscriptionClient! Please set in the constructor.')
     }

--- a/packages/graphql-hooks/test/unit/useSubscription.test.js
+++ b/packages/graphql-hooks/test/unit/useSubscription.test.js
@@ -139,6 +139,38 @@ describe('useSubscription', () => {
     })
   })
 
+  it('works when a factory function is passed to `subscriptionClient`', () => {
+    const data = {
+      data: {
+        onTestEvent: {
+          id: 1
+        }
+      }
+    }
+    mockClient = new GraphQLClient({
+      url: 'fetch-url',
+      subscriptionClient: () =>
+        new MockSubscriptionClient({
+          type: 'DATA',
+          data
+        })
+    })
+    const request = {
+      query: TEST_SUBSCRIPTION,
+      variables: {
+        id: 1
+      }
+    }
+
+    const callback = response => {
+      expect(response).toEqual(data)
+    }
+
+    renderHook(() => useSubscription(request, callback), {
+      wrapper: Wrapper
+    })
+  })
+
   it('calls the update callback when subscription receives errors', () => {
     const graphqlErrors = [{ message: 'error1' }, { message: 'error2' }]
     const subscriptionClient = new MockSubscriptionClient({


### PR DESCRIPTION
### What does this PR do?

Adds an option for lazily instantiate the subscription client in order to provide an easier support for ssr without introducing breaking changes.

### Related issues

closes https://github.com/nearform/graphql-hooks/issues/681

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
