### PR TITLE
feat: add tsd tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test:coverage
-      - run: npm run tsd:hooks
+      - run: npm run tsd
       - uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test:coverage
+      - run: npm run tsd:hooks
       - uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:packages": "lerna run build --no-private",
     "build:site": "lerna run build --scope=create-react-app",
     "postinstall": "lerna bootstrap --hoist --no-ci && npm run build:packages",
-    "tsd:hooks": "lerna exec tsd --scope=graphql-hooks",
+    "tsd": "lerna run tsd",
     "lint": "eslint .",
     "prettier": "prettier '**/*.js' '**/*.md' '**/*.ts' --write",
     "release": "lerna publish",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:packages": "lerna run build --no-private",
     "build:site": "lerna run build --scope=create-react-app",
     "postinstall": "lerna bootstrap --hoist --no-ci && npm run build:packages",
+    "tsd:hooks": "lerna exec tsd --scope=graphql-hooks",
     "lint": "eslint .",
     "prettier": "prettier '**/*.js' '**/*.md' '**/*.ts' --write",
     "release": "lerna publish",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "rollup-plugin-size-snapshot": "^0.12.0",
     "rollup-plugin-terser": "^7.0.0",
     "testcafe": "^1.14.0",
-    "testcafe-reporter-xunit": "^2.1.0"
+    "testcafe-reporter-xunit": "^2.1.0",
+    "tsd": "^0.19.1"
   },
   "lint-staged": {
     "**/*.js": [

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "rollup-plugin-size-snapshot": "^0.12.0",
     "rollup-plugin-terser": "^7.0.0",
     "testcafe": "^1.14.0",
-    "testcafe-reporter-xunit": "^2.1.0",
-    "tsd": "^0.19.1"
+    "testcafe-reporter-xunit": "^2.1.0"
   },
   "lint-staged": {
     "**/*.js": [

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -49,7 +49,8 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-test-renderer": "^17.0.0",
-    "subscriptions-transport-ws": "^0.11.0"
+    "subscriptions-transport-ws": "^0.11.0",
+    "tsd": "^0.19.1"
   },
   "repository": {
     "type": "git",

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "clean": "rm -rf ./dist ./es ./lib",
     "build": "rollup -c",
-    "prepublishOnly": "npm run build && cp ../../README.md . && cp ../../LICENSE ."
+    "prepublishOnly": "npm run build && cp ../../README.md . && cp ../../LICENSE .",
+    "tsd": "tsd"
   },
   "files": [
     "dist",

--- a/packages/graphql-hooks/test-d/cache.test-d.ts
+++ b/packages/graphql-hooks/test-d/cache.test-d.ts
@@ -1,0 +1,42 @@
+import { expectType } from 'tsd'
+import { CacheKeyObject, Operation, Cache } from '..'
+
+const query = 'query { foobar }'
+
+const operation: Operation = {
+  query
+}
+
+class TestCacheKeyObject implements CacheKeyObject {
+  operation = operation
+  fetchOptions: object = {}
+}
+
+const cacheKeyObject = new TestCacheKeyObject()
+
+expectType<Operation>(cacheKeyObject.operation)
+expectType<object>(cacheKeyObject.fetchOptions)
+
+class TestCache implements Cache {
+  get(keyObject: CacheKeyObject): object {
+    return {}
+  }
+
+  set(keyObject: CacheKeyObject, data: object): void {}
+
+  delete(keyObject: CacheKeyObject): void {}
+
+  clear(): void {}
+  keys(): void {}
+  getInitialState(): object {
+    return {}
+  }
+}
+const cache = new TestCache()
+
+expectType<(keyObject: CacheKeyObject) => object>(cache.get)
+expectType<(keyObject: CacheKeyObject, data: object) => void>(cache.set)
+expectType<(keyObject: CacheKeyObject) => void>(cache.delete)
+expectType<() => void>(cache.clear)
+expectType<() => void>(cache.keys)
+expectType<() => object>(cache.getInitialState)

--- a/packages/graphql-hooks/test-d/client-options.test-d.ts
+++ b/packages/graphql-hooks/test-d/client-options.test-d.ts
@@ -1,0 +1,44 @@
+import { Client } from 'graphql-ws'
+import { SubscriptionClient } from 'subscriptions-transport-ws'
+import { expectType } from 'tsd'
+import { ClientOptions, Cache, Headers, Operation, Result } from '..'
+
+const subscriptionClient = new SubscriptionClient('')
+
+class TestClientOptions implements ClientOptions {
+  url = 'https://my.graphql.api'
+  cache?: Cache = undefined
+  headers?: Headers = { foo: 'bar'}
+  ssrMode? = false
+  useGETForQueries? = false
+  subscriptionClient?:SubscriptionClient | Client  = subscriptionClient
+  fetchOptions?: object = {}
+  FormData?: any = {}
+  logErrors? = false
+
+
+  fetch?(url: string, options?: object): Promise<object> {
+    return Promise.resolve({})
+  }
+
+  onError?({
+    result,
+    operation
+  }: {
+    operation: Operation<object>
+    result: Result<any, object>
+  }): void {}
+}
+
+const clientOptions = new TestClientOptions()
+
+expectType<string>(clientOptions.url)
+expectType<Cache | undefined>(clientOptions.cache)
+expectType<Headers | undefined>(clientOptions.headers)
+expectType<boolean | undefined>(clientOptions.ssrMode)
+expectType<boolean | undefined>(clientOptions.useGETForQueries)
+expectType<SubscriptionClient | Client | undefined>(clientOptions.subscriptionClient)
+expectType<((url: string, options?: object) => Promise<object>) | undefined>(clientOptions.fetch)
+expectType<object | undefined>(clientOptions.fetchOptions)
+expectType<any | undefined>(clientOptions.FormData)
+expectType<boolean | undefined>(clientOptions.logErrors)

--- a/packages/graphql-hooks/test-d/client.test-d.ts
+++ b/packages/graphql-hooks/test-d/client.test-d.ts
@@ -1,0 +1,95 @@
+import EventEmitter from 'events'
+import { expectType } from 'tsd'
+import {
+  GraphQLClient,
+  Cache,
+  Headers,
+  UseClientRequestOptions,
+  Operation,
+  CacheKeyObject,
+  Result
+} from '..'
+
+const client = new GraphQLClient({ url: 'https://my.graphql.api' })
+
+const query = 'query { foobar }'
+
+const operation: Operation = {
+  query
+}
+
+expectType<Cache>(client.cache)
+expectType<Headers>(client.headers)
+expectType<boolean>(client.ssrMode)
+expectType<object>(client.fetchOptions)
+expectType<any | undefined>(client.FormData)
+expectType<boolean>(client.logErrors)
+expectType<boolean>(client.useGETForQueries)
+expectType<EventEmitter>(client.mutationsEmitter)
+expectType<boolean>(client.logErrors)
+
+expectType<(key: string, value: string) => GraphQLClient>(client.setHeader)
+expectType<GraphQLClient>(client.setHeader('some', 'string'))
+
+expectType<(headers: Headers) => GraphQLClient>(client.setHeaders)
+expectType<GraphQLClient>(client.setHeaders({ some: 'string' }))
+
+expectType<(key: string) => GraphQLClient>(client.removeHeader)
+expectType<GraphQLClient>(client.removeHeader('some'))
+
+expectType<<Variables = object>(
+  operation: Operation<object>,
+  options: UseClientRequestOptions<any, Variables>
+) => CacheKeyObject>(client.getCacheKey)
+expectType<CacheKeyObject>(client.getCacheKey(operation, {}))
+
+const cacheKey: CacheKeyObject = {
+  operation,
+  fetchOptions: {}
+}
+
+expectType<(cacheKey: CacheKeyObject) => undefined | object>(client.getCache)
+expectType<undefined | object>(client.getCache(cacheKey))
+
+expectType<(cacheKey: CacheKeyObject, value: object) => void>(client.saveCache)
+expectType<void>(client.saveCache(cacheKey, {}))
+
+expectType<<Variables = object>(
+  operation: Operation<Variables>,
+  fetchOptionsOverrides?: object | undefined
+) => object>(client.getFetchOptions)
+expectType<object>(client.getFetchOptions(operation))
+
+expectType<<ResponseData, TGraphQLError = object, Variables = object>(
+  operation: Operation<Variables>,
+  options?: object | undefined
+) => Promise<Result<ResponseData, TGraphQLError>>>(client.request)
+expectType<Promise<Result>>(client.request(operation))
+expectType<Promise<Result>>(client.request(operation, {}))
+
+const result = {
+  data: {},
+  error: {
+    fetchError: new Error('fetch error'),
+    httpError: {
+      body: 'http error',
+      status: 401,
+      statusText: 'invalid request'
+    }
+  }
+}
+
+expectType<<ResponseData, TGraphQLError = object>({
+  result,
+  operation
+}: {
+  result: Result<ResponseData, TGraphQLError>
+  operation: Operation<object>
+}) => void>(client.logErrorResult)
+expectType<void>(
+  client.logErrorResult({
+    result,
+    operation
+  })
+)
+expectType<void>(client.logErrorResult({ result: {}, operation: { query } }))

--- a/packages/graphql-hooks/test-d/hooks.test-d.ts
+++ b/packages/graphql-hooks/test-d/hooks.test-d.ts
@@ -1,0 +1,54 @@
+import { expectType } from 'tsd'
+import {
+  FetchData,
+  ResetFunction,
+  useClientRequest,
+  UseClientRequestOptions,
+  UseClientRequestResult,
+  useManualQuery,
+  useMutation,
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult
+} from '..'
+
+const query = 'query { foobar }'
+const mutation = 'mutation { foobar() }'
+
+class TestUseClientRequestOptions implements UseClientRequestOptions {
+  useCache? = false
+  isMutation? = false
+  isManual? = false
+  variables?: object = {
+    foo: 'bar'
+  }
+  operationName? = 'operation'
+  skipCache? = true
+}
+
+const clientRequestOptions = new TestUseClientRequestOptions()
+
+type UseClientRequestReturn = [
+  FetchData<any, object, object>,
+  UseClientRequestResult<any, object>,
+  ResetFunction
+]
+expectType<UseClientRequestReturn>(useClientRequest(query))
+expectType<UseClientRequestReturn>(useClientRequest(query, clientRequestOptions))
+
+const useQueryOptions: UseQueryOptions = {
+  ssr: false,
+  skip: false,
+  refetchAfterMutations: [{ mutation }]
+}
+
+expectType<UseQueryResult<any, object, object>>(useQuery(query))
+expectType<UseQueryResult<any, object, object>>(
+  useQuery(query, useQueryOptions)
+)
+
+expectType<UseClientRequestReturn>(useManualQuery(query))
+expectType<UseClientRequestReturn>(useManualQuery(query, clientRequestOptions))
+
+expectType<UseClientRequestReturn>(useMutation(mutation))
+expectType<UseClientRequestReturn>(useMutation(mutation, clientRequestOptions))

--- a/packages/graphql-hooks/test-d/operation.test-d.ts
+++ b/packages/graphql-hooks/test-d/operation.test-d.ts
@@ -1,0 +1,15 @@
+import { expectType } from "tsd"
+import { Operation } from ".."
+
+const query = 'query { foobar }'
+
+class TestOperation implements Operation {
+  query = query
+  variables?: object = { foo: 'bar'}
+  operationName? = 'operation'
+}
+export const operation = new TestOperation()
+
+expectType<string>(operation.query)
+expectType<object | undefined>(operation.variables)
+expectType<string | undefined>(operation.operationName)

--- a/packages/graphql-hooks/test-d/subscription.test-d.ts
+++ b/packages/graphql-hooks/test-d/subscription.test-d.ts
@@ -1,0 +1,31 @@
+import { expectType } from 'tsd'
+import { SubscriptionRequest, useSubscription, UseSubscriptionOperation } from '..'
+
+const query = 'query { foobar }'
+
+type UseSubscriptionCallbackResponse = {
+  data?: any
+  errors?: object[]
+}
+const useSubscriptionCallback = (response: UseSubscriptionCallbackResponse) => {
+  expectType<any | undefined>(response.data)
+  expectType<object[] | undefined>(response.errors)
+}
+
+const subscriptionOperation: UseSubscriptionOperation = {
+  query,
+  variables: { foo: 'bar' },
+}
+
+expectType<void>(
+  useSubscription(subscriptionOperation, useSubscriptionCallback)
+)
+
+class TestSubscriptionRequest implements SubscriptionRequest {
+  query = query
+  variables: object = { foo: 'bar' }
+}
+
+const testSubscriptionRequest = new TestSubscriptionRequest()
+expectType<string>(testSubscriptionRequest.query)
+expectType<object>(testSubscriptionRequest.variables)


### PR DESCRIPTION
### What does this PR do?
Add [`tsd`](https://github.com/SamVerschueren/tsd/) tests to `index.d.ts` file of the `graphql-hooks` package.
Also, adds a new CI run for the type tests.
Closes #741

### Related issues

#741

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
