### PR TITLE
fix(typing): add undefined to FetchData Promise return type

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -238,7 +238,7 @@ interface UseSubscriptionOperation<Variables extends object = object>
 
 type FetchData<ResponseData, Variables = object, TGraphQLError = object> = (
   options?: UseClientRequestOptions<ResponseData, Variables>
-) => Promise<UseClientRequestResult<ResponseData, TGraphQLError>>
+) => Promise<UseClientRequestResult<ResponseData, TGraphQLError> | undefined>
 
 interface CacheKeyObject {
   operation: Operation

--- a/packages/graphql-hooks/test-d/hooks.test-d.ts
+++ b/packages/graphql-hooks/test-d/hooks.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectType, expectError } from 'tsd'
 import {
   FetchData,
   ResetFunction,
@@ -35,6 +35,10 @@ type UseClientRequestReturn = [
 ]
 expectType<UseClientRequestReturn>(useClientRequest(query))
 expectType<UseClientRequestReturn>(useClientRequest(query, clientRequestOptions))
+
+const [fetchData] = useClientRequest(query);
+expectType<Promise<UseClientRequestResult<any, object> | undefined>>(fetchData());
+expectError<Promise<UseClientRequestResult<any, object>>>(fetchData());
 
 const useQueryOptions: UseQueryOptions = {
   ssr: false,


### PR DESCRIPTION
The fetchData function of useClientRequest returns an empty Promise if the hook is unmounted. Typing has been updated to reflect this behavior

### What does this PR do?

It fixes a typing error that affects useClientRequest's fetchData function, and as a result, useManualQuery and useMutation too. useClientRequest's fetchData function returns an empty (undefined) Promise if called after the component has unmounted, but this is not currently reflected in its typing. Admittedly, this is an edge case behavior, but it's caused my team hard to reproduce bugs, and since the behavior is codified in useClientRequest.test.js:476 ("returns undefined instantly if not mounted"), it seems appropriate that the typing reflect it.

This would be a breaking change for many projects, but I believe that Typescript's usefulness lies exactly in preventing hard-to-reproduce bugs like those caused by this behavior, so I think it's a small price to pay for correctness.

### Related issues
 Closes #772 

### Checklist

- [X] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [X] I have added or updated any relevant documentation
- [X] I have added or updated any relevant tests
