### PR TITLE
chore: bump eslint version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   env: {
     browser: true,
     node: true,

--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@babel/core": "^7.16.12",
+    "@babel/eslint-parser": "^7.16.5",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
     "@commitlint/cli": "^16.0.1",
     "@commitlint/config-conventional": "^16.0.0",
-    "babel-eslint": "^10.1.0",
     "babel-jest": "^27.0.0",
-    "eslint": "^7.26.0",
+    "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.0.0",
+    "eslint-config-react-app": "^7.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.0.0",
@@ -54,3 +56,4 @@
     "node": "^16"
   }
 }
+


### PR DESCRIPTION
### What does this PR do?

This PR should bump the version of eslint to 8.7.0.

### Related issues
There is a related PR #765

### Checklist

- [ X ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ - ] I have added or updated any relevant documentation
- [ - ] I have added or updated any relevant tests
