### PR TITLE
fix:dont overwrite the cache for ssrMode

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.js
+++ b/packages/graphql-hooks/src/useClientRequest.js
@@ -225,9 +225,10 @@ function useClientRequest(query, initialOpts = {}) {
   )
 
   // We perform caching after reducer update
-  // To include the outcome of updateData
+  // to include the outcome of updateData.
+  // The cache is already saved if in ssrMode.
   React.useEffect(() => {
-    if (state.useCache) {
+    if (state.useCache && !client.ssrMode) {
       client.saveCache(state.cacheKey, state)
     }
   }, [client, state])

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.js
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.js
@@ -201,7 +201,7 @@ describe('useClientRequest', () => {
       }
     })
 
-    await fetchData()
+    await act(fetchData)
 
     expect(state).toEqual({
       cacheHit: false,


### PR DESCRIPTION
### What does this PR do?

This PR avoids the overwrite of the cache if in SSR mode. In SSR mode the cache is already saved during fetchData execution. There is also a useEffect that is saving the cache after the store updates have finished. 

A test for useClientRequest did not wrap a call in act and so the useEffect was not being run in the test. Once the test was updated the test started failing.

### Related issues

Closes https://github.com/nearform/graphql-hooks/issues/68

### Checklist

- [Y] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [Y] I have added or updated any relevant documentation
- [Y] I have added or updated any relevant tests
