### PR TITLE
feat(typescript): adds cacheKey to UseClientRequestResult type

### DIFF
--- a/packages/graphql-hooks/index.d.ts
+++ b/packages/graphql-hooks/index.d.ts
@@ -216,6 +216,7 @@ export interface UseQueryOptions<ResponseData = any, Variables = object>
 interface UseClientRequestResult<ResponseData, TGraphQLError = object> {
   loading: boolean
   cacheHit: boolean
+  cacheKey?: CacheKeyObject
   data?: ResponseData
   error?: APIError<TGraphQLError>
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds `cacheKey` to UseClientRequestResult type

This goal is to be able to access to the `cacheKey` value of the `useQuery` result in Typescript projects.

I'm using it to manually invalidate the cache.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
