### PR TITLE
fix: update fetch bind

### DIFF
--- a/packages/graphql-hooks/src/GraphQLClient.ts
+++ b/packages/graphql-hooks/src/GraphQLClient.ts
@@ -56,7 +56,9 @@ class GraphQLClient {
     this.url = config.url
     this.fetch =
       config.fetch ||
-      (typeof fetch !== 'undefined' && fetch ? fetch.bind(this) : undefined)
+      (typeof fetch !== 'undefined' && fetch
+        ? fetch.bind(undefined)
+        : undefined)
     this.fetchOptions = config.fetchOptions || {}
     this.FormData =
       config.FormData ||


### PR DESCRIPTION
Updates fetch binding, fixes `[Fetch TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation]` error

Fixes #821