### PR TITLE
Chore/export definitions correctly

### DIFF
--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -4,6 +4,7 @@ import {
   GraphQLClient,
   useManualQuery,
   useMutation,
+  useSubscription,
   useQuery
 } from 'graphql-hooks'
 import React, { useState } from 'react'

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -51,7 +51,6 @@ function AddPost() {
   const [url, setUrl] = useState('')
   const [createPost, { loading, error }] = useMutation(createPostMutation)
 
-
   async function handleSubmit(e: any) {
     e.preventDefault()
     await createPost({ variables: { title, url } })

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -52,6 +52,7 @@ function AddPost() {
   const [url, setUrl] = useState('')
   const [createPost, { loading, error }] = useMutation(createPostMutation)
 
+
   async function handleSubmit(e: any) {
     e.preventDefault()
     await createPost({ variables: { title, url } })

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -4,7 +4,6 @@ import {
   GraphQLClient,
   useManualQuery,
   useMutation,
-  useSubscription,
   useQuery
 } from 'graphql-hooks'
 import React, { useState } from 'react'

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -5,7 +5,7 @@
   "main": "lib/graphql-hooks.js",
   "module": "es/graphql-hooks.js",
   "unpkg": "dist/graphql-hooks.min.js",
-  "types": "lib/types/index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./dist ./es ./lib",
     "build": "npm run build:code && npm run build:types",

--- a/packages/graphql-hooks/rollup.config.js
+++ b/packages/graphql-hooks/rollup.config.js
@@ -10,7 +10,7 @@ export default generateRollupConfig({
 }).concat({
   input: 'src/middlewares/apqMiddleware.ts',
   output: {
-    file: `lib/middlewares/apqMiddleware.js`,
+    file: 'lib/middlewares/apqMiddleware.js',
     format: 'cjs',
     indent: false
   },

--- a/packages/graphql-hooks/src/GraphQLClient.ts
+++ b/packages/graphql-hooks/src/GraphQLClient.ts
@@ -15,7 +15,8 @@ import type {
   Operation,
   RequestOptions,
   Result,
-  GraphQLResponseError
+  GraphQLResponseError,
+  CacheKeyObject
 } from './types/common-types'
 import { pipeP } from './utils'
 
@@ -174,7 +175,7 @@ class GraphQLClient {
   getCacheKey<Variables = object>(
     operation: Operation,
     options: UseClientRequestOptions<any, Variables> = {}
-  ) {
+  ): CacheKeyObject {
     const fetchOptions = {
       ...this.fetchOptions,
       ...options.fetchOptionsOverrides

--- a/packages/graphql-hooks/src/index.ts
+++ b/packages/graphql-hooks/src/index.ts
@@ -5,13 +5,47 @@ import LocalGraphQLError from './LocalGraphQLError'
 import useClientRequest from './useClientRequest'
 import useQuery from './useQuery'
 import useSubscription from './useSubscription'
+import {
+  UseClientRequestOptions,
+  FetchData,
+  UseClientRequestResult,
+  ResetFunction
+} from './types/common-types'
+
 export * from './types/common-types'
 
-const useManualQuery = (query, options = {}) =>
-  useClientRequest(query, { useCache: true, isManual: true, ...options })
+const useManualQuery = <
+  ResponseData = any,
+  Variables = object,
+  TGraphQLError = object
+>(
+  query: string,
+  options: Omit<
+    UseClientRequestOptions<ResponseData, Variables>,
+    'useCache' | 'isManual'
+  > = {}
+): [
+  FetchData<ResponseData, Variables, TGraphQLError>,
+  UseClientRequestResult<ResponseData, TGraphQLError>,
+  ResetFunction
+] =>
+  useClientRequest(query, { useCache: true, isManual: true, ...options }) as any
 
-const useMutation = (query, options = {}) =>
-  useClientRequest(query, { isMutation: true, ...options })
+const useMutation = <
+  ResponseData = any,
+  Variables = object,
+  TGraphQLError = object
+>(
+  query: string,
+  options: Omit<
+    UseClientRequestOptions<ResponseData, Variables>,
+    'isMutation'
+  > = {}
+): [
+  FetchData<ResponseData, Variables, TGraphQLError>,
+  UseClientRequestResult<ResponseData, TGraphQLError>,
+  ResetFunction
+] => useClientRequest(query, { isMutation: true, ...options }) as any
 
 export {
   ClientContext,

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -92,28 +92,6 @@ declare function useClientRequest<
   ResetFunction
 ]
 
-declare function useQuery<
-  ResponseData = any,
-  Variables = object,
-  TGraphQLError = object
->(
-  query: string,
-  options?: UseQueryOptions<ResponseData, Variables>
-): UseQueryResult<ResponseData, Variables, TGraphQLError>
-
-declare function useManualQuery<
-  ResponseData = any,
-  Variables = object,
-  TGraphQLError = object
->(
-  query: string,
-  options?: UseClientRequestOptions<ResponseData, Variables>
-): [
-  FetchData<ResponseData, Variables, TGraphQLError>,
-  UseClientRequestResult<ResponseData, TGraphQLError>,
-  ResetFunction
-]
-
 declare function useMutation<
   ResponseData = any,
   Variables = object,

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -79,32 +79,6 @@ declare class LocalGraphQLError<TGraphQLError = object>
   constructor(error: APIError<TGraphQLError>)
 }
 
-declare function useClientRequest<
-  ResponseData = any,
-  Variables = object,
-  TGraphQLError = object
->(
-  query: string,
-  options?: UseClientRequestOptions<ResponseData, Variables>
-): [
-  FetchData<ResponseData, Variables, TGraphQLError>,
-  UseClientRequestResult<ResponseData, TGraphQLError>,
-  ResetFunction
-]
-
-declare function useMutation<
-  ResponseData = any,
-  Variables = object,
-  TGraphQLError = object
->(
-  query: string,
-  options?: UseClientRequestOptions<ResponseData, Variables>
-): [
-  FetchData<ResponseData, Variables, TGraphQLError>,
-  UseClientRequestResult<ResponseData, TGraphQLError>,
-  ResetFunction
-]
-
 export interface SubscriptionRequest {
   query: string
   variables: object

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -240,6 +240,7 @@ export interface UseQueryOptions<ResponseData = any, Variables = object>
   ssr?: boolean
   skip?: boolean
   refetchAfterMutations?: RefetchAferMutationsData
+  [key: string]: any
 }
 
 export interface UseClientRequestResult<

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -101,7 +101,7 @@ function useClientRequest<
   const contextClient = React.useContext(ClientContext)
   const client = initialOpts.client || contextClient
 
-  if (client === null) {
+  if (client === null || client === undefined) {
     throw new Error(
       'A client must be provided in order to use the useClientRequest hook.'
     )

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -62,14 +62,14 @@ function reducer(state, action) {
   }
 }
 
-function useDeepCompareCallback(callback, deps) {
-  const ref = React.useRef<DependencyList>()
+function useDeepCompareCallback(callback, deps: DependencyList) {
+  const ref = React.useRef<DependencyList>(deps)
 
   if (!dequal(deps, ref.current)) {
     ref.current = deps
   }
 
-  return React.useCallback(callback, ref.current || [])
+  return React.useCallback(callback, ref.current)
 }
 
 /*

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -213,10 +213,10 @@ function useClientRequest<
           throw new Error('options.updateData must be a function')
         }
 
-        const actionResult = { ...result }
+        const actionResult: any = { ...result }
         if (revisedOpts.useCache) {
-          ;(actionResult as any).useCache = true
-          ;(actionResult as any).cacheKey = revisedCacheKey
+          actionResult.useCache = true
+          actionResult.cacheKey = revisedCacheKey
 
           if (client.ssrMode) {
             const cacheValue = {

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -63,13 +63,13 @@ function reducer(state, action) {
 }
 
 function useDeepCompareCallback(callback, deps: DependencyList) {
-  const ref = React.useRef<DependencyList>(deps)
+  const ref = React.useRef<DependencyList>()
 
   if (!dequal(deps, ref.current)) {
     ref.current = deps
   }
 
-  return React.useCallback(callback, ref.current)
+  return React.useCallback(callback, ref.current as any)
 }
 
 /*
@@ -118,7 +118,7 @@ function useClientRequest<
 
   if (
     initialOpts.persisted ||
-    (client?.useGETForQueries && !initialOpts.isMutation)
+    (client.useGETForQueries && !initialOpts.isMutation)
   ) {
     initialOpts.fetchOptionsOverrides = {
       ...initialOpts.fetchOptionsOverrides,
@@ -192,7 +192,7 @@ function useClientRequest<
 
       const cacheHit = revisedOpts.skipCache
         ? null
-        : client?.getCache(revisedCacheKey)
+        : client.getCache(revisedCacheKey)
 
       if (cacheHit) {
         dispatch({
@@ -205,7 +205,7 @@ function useClientRequest<
       }
 
       dispatch({ type: actionTypes.LOADING, initialState })
-      return client?.request(revisedOperation, revisedOpts).then(result => {
+      return client.request(revisedOperation, revisedOpts).then(result => {
         if (
           revisedOpts.updateData &&
           typeof revisedOpts.updateData !== 'function'
@@ -255,8 +255,8 @@ function useClientRequest<
   // to include the outcome of updateData.
   // The cache is already saved if in ssrMode.
   React.useEffect(() => {
-    if (state.useCache && !client?.ssrMode) {
-      client?.saveCache(state.cacheKey, state)
+    if (state.useCache && !client.ssrMode) {
+      client.saveCache(state.cacheKey, state)
     }
   }, [client, state])
 

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -25,8 +25,14 @@ function useQuery<
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false)
   const [queryReq, state] = useClientRequest(query, allOpts)
 
+  if (!client) {
+    throw new Error(
+      'useQuery() requires a client to be passed in the options or as a context value'
+    )
+  }
+
   if (
-    client?.ssrMode &&
+    client.ssrMode &&
     opts.ssr !== false &&
     !calledDuringSSR &&
     !opts.skipCache &&
@@ -83,16 +89,16 @@ function useQuery<
 
       mutations.forEach(mutation => {
         // this event is emitted from useClientRequest
-        client?.mutationsEmitter.on(mutation, conditionalRefetch)
+        client.mutationsEmitter.on(mutation, conditionalRefetch)
       })
 
       return () => {
         mutations.forEach(mutation => {
-          client?.mutationsEmitter.removeListener(mutation, conditionalRefetch)
+          client.mutationsEmitter.removeListener(mutation, conditionalRefetch)
         })
       }
     },
-    [opts.refetchAfterMutations, refetch, client?.mutationsEmitter]
+    [opts.refetchAfterMutations, refetch, client.mutationsEmitter]
   )
 
   return {

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -3,13 +3,22 @@ import ClientContext from './ClientContext'
 import createRefetchMutationsMap from './createRefetchMutationsMap'
 import useClientRequest from './useClientRequest'
 
+import { UseQueryOptions, UseQueryResult } from './types/common-types'
+
 const defaultOpts = {
   useCache: true,
   skip: false,
   throwErrors: false
 }
 
-function useQuery(query, opts = {}) {
+function useQuery<
+  ResponseData = any,
+  Variables = object,
+  TGraphQLError = object
+>(
+  query: string,
+  opts: UseQueryOptions<ResponseData, Variables> = {}
+): UseQueryResult<ResponseData, Variables, TGraphQLError> {
   const allOpts = { ...defaultOpts, ...opts }
   const contextClient = React.useContext(ClientContext)
   const client = opts.client || contextClient
@@ -17,7 +26,7 @@ function useQuery(query, opts = {}) {
   const [queryReq, state] = useClientRequest(query, allOpts)
 
   if (
-    client.ssrMode &&
+    client?.ssrMode &&
     opts.ssr !== false &&
     !calledDuringSSR &&
     !opts.skipCache &&
@@ -74,16 +83,16 @@ function useQuery(query, opts = {}) {
 
       mutations.forEach(mutation => {
         // this event is emitted from useClientRequest
-        client.mutationsEmitter.on(mutation, conditionalRefetch)
+        client?.mutationsEmitter.on(mutation, conditionalRefetch)
       })
 
       return () => {
         mutations.forEach(mutation => {
-          client.mutationsEmitter.removeListener(mutation, conditionalRefetch)
+          client?.mutationsEmitter.removeListener(mutation, conditionalRefetch)
         })
       }
     },
-    [opts.refetchAfterMutations, refetch, client.mutationsEmitter]
+    [opts.refetchAfterMutations, refetch, client?.mutationsEmitter]
   )
 
   return {

--- a/packages/graphql-hooks/src/useSubscription.ts
+++ b/packages/graphql-hooks/src/useSubscription.ts
@@ -2,12 +2,30 @@ import { useContext, useRef, useEffect } from 'react'
 
 import ClientContext from './ClientContext'
 
-function useSubscription(options, callback) {
+import { UseSubscriptionOperation } from './types/common-types'
+
+function useSubscription<
+  ResponseData = any,
+  Variables extends object = object,
+  TGraphQLError = object
+>(
+  options: UseSubscriptionOperation<Variables>,
+  callback: (response: {
+    data?: ResponseData
+    errors?: TGraphQLError[]
+  }) => void
+): void {
   const callbackRef = useRef(callback)
   callbackRef.current = callback
 
   const contextClient = useContext(ClientContext)
   const client = options.client || contextClient
+
+  if (!client) {
+    throw new Error(
+      'useSubscription() requires a client to be passed in the options or as a context value'
+    )
+  }
 
   const request = {
     query: options.query,
@@ -19,10 +37,10 @@ function useSubscription(options, callback) {
 
     const subscription = observable.subscribe({
       next: result => {
-        callbackRef.current(result)
+        callbackRef.current(result as any)
       },
       error: errors => {
-        callbackRef.current({ errors })
+        callbackRef.current({ errors } as any)
       },
       complete: () => {
         subscription.unsubscribe()

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.tsx
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.tsx
@@ -62,7 +62,7 @@ describe('useClientRequest', () => {
       },
       request: jest.fn().mockResolvedValue({ data: 'data' })
     }
-    const options = { isMutation: false, client: mockClient2 }
+    const options = { isMutation: false, client: mockClient2 } as any;
     let fetchData
     renderHook(() => ([fetchData] = useClientRequest(TEST_QUERY, options)), {
       wrapper: Wrapper
@@ -311,7 +311,7 @@ describe('useClientRequest', () => {
   })
 
   it('throws if the supplied query is not a string', () => {
-    const rendered = renderHook(() => useClientRequest({}), {
+    const rendered = renderHook(() => useClientRequest({} as any), {
       wrapper: Wrapper
     })
     expect(rendered?.result?.error?.message).toMatch(
@@ -661,7 +661,7 @@ describe('useClientRequest', () => {
             ([fetchData] = useClientRequest(TEST_QUERY, {
               variables: { limit: 10 },
               updateData: 'do I look like a function to you?'
-            })),
+            } as any)),
           { wrapper: Wrapper }
         )
 
@@ -836,7 +836,7 @@ describe('useClientRequest', () => {
       let fetchData
 
       renderHook(
-        () => ([fetchData] = useClientRequest(TEST_MUTATION, options)),
+        () => ([fetchData] = useClientRequest(TEST_MUTATION, options as any)),
         {
           wrapper: Wrapper
         }

--- a/packages/graphql-hooks/test/unit/useClientRequest.test.tsx
+++ b/packages/graphql-hooks/test/unit/useClientRequest.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks'
 import React from 'react'
-import { ClientContext, useClientRequest } from '../../src'
+import { ClientContext, useClientRequest, UseClientRequestOptions } from '../../src'
 
 let mockClient
 
@@ -49,7 +49,7 @@ describe('useClientRequest', () => {
   })
 
   it('uses a passed client', async () => {
-    const mockClient2 = {
+    const mockClient2: any = {
       mutationsEmitter: {
         emit: jest.fn()
       },
@@ -62,7 +62,7 @@ describe('useClientRequest', () => {
       },
       request: jest.fn().mockResolvedValue({ data: 'data' })
     }
-    const options = { isMutation: false, client: mockClient2 } as any;
+    const options: UseClientRequestOptions = { isMutation: false, client: mockClient2 };
     let fetchData
     renderHook(() => ([fetchData] = useClientRequest(TEST_QUERY, options)), {
       wrapper: Wrapper
@@ -74,6 +74,14 @@ describe('useClientRequest', () => {
       { query: TEST_QUERY },
       options
     )
+  })
+
+  it('returns an error if there is no client available', () => {
+    const options: UseClientRequestOptions = { isMutation: false }
+
+    const { result } = renderHook(() => useClientRequest(TEST_QUERY, options))
+
+    expect(result.error?.message).toEqual( 'A client must be provided in order to use the useClientRequest hook.')
   })
 
   it('resets data when reset function is called', async () => {
@@ -812,7 +820,7 @@ describe('useClientRequest', () => {
     })
 
     it('emits an event when a mutation returns its result', async () => {
-      const mockClient = {
+      const mockClient: any = {
         mutationsEmitter: {
           emit: jest.fn()
         },
@@ -825,7 +833,7 @@ describe('useClientRequest', () => {
         },
         request: jest.fn().mockResolvedValue({ data: 'data' })
       }
-      const options = {
+      const options: UseClientRequestOptions = {
         isMutation: true,
         client: mockClient,
         variables: {
@@ -836,7 +844,7 @@ describe('useClientRequest', () => {
       let fetchData
 
       renderHook(
-        () => ([fetchData] = useClientRequest(TEST_MUTATION, options as any)),
+        () => ([fetchData] = useClientRequest(TEST_MUTATION, options)),
         {
           wrapper: Wrapper
         }

--- a/packages/graphql-hooks/test/unit/useManualQuery.test.ts
+++ b/packages/graphql-hooks/test/unit/useManualQuery.test.ts
@@ -10,10 +10,10 @@ const TEST_QUERY = `query Test($limit: Int) {
 
 describe('useManualQuery', () => {
   it('calls useClientRequest with useCache set to true & options', () => {
-    useManualQuery(TEST_QUERY, { option: 'option' })
+    useManualQuery(TEST_QUERY, { isMutation: true })
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       useCache: true,
-      option: 'option',
+      isMutation: true,
       isManual: true
     })
   })

--- a/packages/graphql-hooks/test/unit/useMutation.test.ts
+++ b/packages/graphql-hooks/test/unit/useMutation.test.ts
@@ -10,10 +10,10 @@ const TEST_QUERY = `query Test($limit: Int) {
 
 describe('useMutation', () => {
   it('calls useClientRequest with options and isMutation set to true', () => {
-    useMutation(TEST_QUERY, { option: 'option' })
+    useMutation(TEST_QUERY, { isManual: true })
     expect(useClientRequest).toHaveBeenCalledWith(TEST_QUERY, {
       isMutation: true,
-      option: 'option'
+      isManual: true
     })
   })
 })

--- a/packages/graphql-hooks/test/unit/useQuery.test.tsx
+++ b/packages/graphql-hooks/test/unit/useQuery.test.tsx
@@ -55,6 +55,11 @@ describe('useQuery', () => {
     })
   })
 
+  it('throws an error if not provided with an appropriate client', () => {
+    const { result } = renderHook(() => useQuery(TEST_QUERY, { useCache: true }))
+    expect(result.error?.message).toEqual('useQuery() requires a client to be passed in the options or as a context value')
+  })
+
   it('calls useClientRequest with options', () => {
     renderHook(
       () =>

--- a/packages/graphql-hooks/test/unit/useQuery.test.tsx
+++ b/packages/graphql-hooks/test/unit/useQuery.test.tsx
@@ -454,7 +454,7 @@ describe('useQuery', () => {
         ({ throwErrors }) =>
           useQuery(TEST_QUERY, {
             throwErrors
-          }),
+          } as any),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -477,7 +477,7 @@ describe('useQuery', () => {
       const { unmount } = renderHook(
         () =>
           useQuery(TEST_QUERY, {
-            client: mockClient,
+            client: mockClient as any,
             refetchAfterMutations: [
               {
                 mutation: MY_MUTATION
@@ -509,11 +509,11 @@ describe('useQuery', () => {
       renderHook(
         () =>
           useQuery(TEST_QUERY, {
-            client: mockClient,
+            client: mockClient as any,
             refetchAfterMutations: [
               {
                 mutation: MY_MUTATION,
-                filter: ({ userId }) => userId === 1
+                filter: ({ userId }: any) => userId === 1
               }
             ]
           }),

--- a/packages/graphql-hooks/test/unit/useQuery.test.tsx
+++ b/packages/graphql-hooks/test/unit/useQuery.test.tsx
@@ -33,7 +33,7 @@ describe('useQuery', () => {
   beforeEach(() => {
     mockQueryReq = jest.fn()
     mockState = { loading: true, cacheHit: false }
-    mockUseClientRequest.mockReturnValue([mockQueryReq, mockState])
+    mockUseClientRequest.mockReturnValue([mockQueryReq, mockState] as any)
 
     mockClient = {
       ssrMode: false,
@@ -318,8 +318,8 @@ describe('useQuery', () => {
   describe('useQuery.refetch memoisation', () => {
     it('returns the same function on every render if options remain the same', () => {
       mockUseClientRequest
-        .mockReturnValueOnce([mockQueryReq, mockState])
-        .mockReturnValueOnce([mockQueryReq, mockState])
+        .mockReturnValueOnce([mockQueryReq, mockState] as any)
+        .mockReturnValueOnce([mockQueryReq, mockState] as any)
 
       const refetchFns: any[] = []
       const { rerender } = renderHook(
@@ -337,8 +337,8 @@ describe('useQuery', () => {
 
     it('returns a new function if the query changes', () => {
       mockUseClientRequest
-        .mockReturnValueOnce([jest.fn(), mockState])
-        .mockReturnValueOnce([jest.fn(), mockState])
+        .mockReturnValueOnce([jest.fn(), mockState] as any)
+        .mockReturnValueOnce([jest.fn(), mockState] as any)
 
       const refetchFns: any[] = []
       const { rerender } = renderHook(
@@ -373,7 +373,7 @@ describe('useQuery', () => {
   describe('skip option', () => {
     it('should skip query if `skip` is `true`', () => {
       const queryReqMock = jest.fn()
-      mockUseClientRequest.mockReturnValue([queryReqMock, mockState])
+      mockUseClientRequest.mockReturnValue([queryReqMock, mockState] as any)
 
       renderHook(
         ({ skip }) =>
@@ -393,7 +393,7 @@ describe('useQuery', () => {
 
     it('should query if `skip` value changes from `true` to `false`', () => {
       const queryReqMock = jest.fn()
-      mockUseClientRequest.mockReturnValue([queryReqMock, mockState])
+      mockUseClientRequest.mockReturnValue([queryReqMock, mockState] as any)
       const { rerender } = renderHook(
         ({ skip }) =>
           useQuery(TEST_QUERY, {
@@ -414,7 +414,7 @@ describe('useQuery', () => {
 
     it('should not execute query again query if `skip` value changes from `false` to `true`', () => {
       const queryReqMock = jest.fn()
-      mockUseClientRequest.mockReturnValue([queryReqMock, mockState])
+      mockUseClientRequest.mockReturnValue([queryReqMock, mockState] as any)
       const { rerender } = renderHook(
         ({ skip }) =>
           useQuery(TEST_QUERY, {
@@ -448,7 +448,7 @@ describe('useQuery', () => {
     it('should throw error if `throwErrors` is `true`', () => {
       const errorState = { error: new Error('boom') }
 
-      mockUseClientRequest.mockReturnValue([jest.fn(), errorState])
+      mockUseClientRequest.mockReturnValue([jest.fn(), errorState] as any)
 
       const { result } = renderHook(
         ({ throwErrors }) =>

--- a/packages/graphql-hooks/test/unit/useSubscription.test.tsx
+++ b/packages/graphql-hooks/test/unit/useSubscription.test.tsx
@@ -118,6 +118,19 @@ describe('useSubscription', () => {
     expect(mockClient.createSubscription).toHaveBeenCalledWith(request)
   })
 
+  it('throws when not provided an appropriate client', () => {
+    const request = {
+      query: TEST_SUBSCRIPTION,
+      variables: {
+        id: 1
+      }
+    }
+
+    const { result } = renderHook(() => useSubscription(request, jest.fn()))
+
+    expect(result.error?.message).toEqual('useSubscription() requires a client to be passed in the options or as a context value')
+  })
+
   it('calls the update callback when subscription receives data', () => {
     const data = {
       data: {

--- a/packages/graphql-hooks/test/unit/useSubscription.test.tsx
+++ b/packages/graphql-hooks/test/unit/useSubscription.test.tsx
@@ -207,7 +207,7 @@ describe('useSubscription', () => {
       expect(errors).toEqual(graphqlErrors)
     }
 
-    renderHook(() => useSubscription(request, callback), {
+    renderHook(() => useSubscription(request, callback as any), {
       wrapper: Wrapper
     })
   })

--- a/packages/graphql-hooks/tsconfig.json
+++ b/packages/graphql-hooks/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../config/tsconfig.base",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "lib/types"
+    "outDir": "lib"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Converts remaining JS code to TS in the graphql-hooks project, in order to correctly export type definitions. Previously, declarations being made on the global scope weren't being considered due to declarations being generated directly from the JS files.

Note: tests all pass, but there are some functional changes in this PR, notably certain functions now throw errors if not provided with an appropriate client to use for requests.

### Related issues

Closes https://github.com/nearform/graphql-hooks/issues/838

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
