### PR TITLE
fix: set loading to false when skip is true

### DIFF
--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -166,6 +166,7 @@ export interface UseClientRequestOptions<
   useCache?: boolean
   isMutation?: boolean
   isManual?: boolean
+  skip?: boolean
   variables?: Variables
   operationName?: string
   skipCache?: boolean
@@ -181,7 +182,7 @@ export type RefetchAfterMutationItem = {
   filter?: (variables: object) => boolean
 }
 
-export type RefetchAferMutationsData =
+export type RefetchAfterMutationsData =
   | string
   | string[]
   | RefetchAfterMutationItem
@@ -190,8 +191,7 @@ export type RefetchAferMutationsData =
 export interface UseQueryOptions<ResponseData = any, Variables = object>
   extends UseClientRequestOptions<ResponseData, Variables> {
   ssr?: boolean
-  skip?: boolean
-  refetchAfterMutations?: RefetchAferMutationsData
+  refetchAfterMutations?: RefetchAfterMutationsData
   [key: string]: any
 }
 

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -127,7 +127,8 @@ function useClientRequest<
   }
 
   const cacheKey = client.getCacheKey(operation, initialOpts)
-  const isDeferred = initialOpts.isMutation || initialOpts.isManual
+  const isDeferred =
+    initialOpts.isMutation || initialOpts.isManual || initialOpts.skip
   const initialCacheHit =
     initialOpts.skipCache || !client.cache || !cacheKey
       ? null

--- a/packages/graphql-hooks/test-jsdom/unit/useClientRequest.test.tsx
+++ b/packages/graphql-hooks/test-jsdom/unit/useClientRequest.test.tsx
@@ -1,6 +1,10 @@
 import { act, renderHook } from '@testing-library/react-hooks'
 import React from 'react'
-import { ClientContext, useClientRequest, UseClientRequestOptions } from '../../src'
+import {
+  ClientContext,
+  useClientRequest,
+  UseClientRequestOptions
+} from '../../src'
 
 let mockClient
 
@@ -62,7 +66,10 @@ describe('useClientRequest', () => {
       },
       request: jest.fn().mockResolvedValue({ data: 'data' })
     }
-    const options: UseClientRequestOptions = { isMutation: false, client: mockClient2 };
+    const options: UseClientRequestOptions = {
+      isMutation: false,
+      client: mockClient2
+    }
     let fetchData
     renderHook(() => ([fetchData] = useClientRequest(TEST_QUERY, options)), {
       wrapper: Wrapper
@@ -81,7 +88,9 @@ describe('useClientRequest', () => {
 
     const { result } = renderHook(() => useClientRequest(TEST_QUERY, options))
 
-    expect(result.error?.message).toEqual( 'A client must be provided in order to use the useClientRequest hook.')
+    expect(result.error?.message).toEqual(
+      'A client must be provided in order to use the useClientRequest hook.'
+    )
   })
 
   it('resets data when reset function is called', async () => {
@@ -420,6 +429,21 @@ describe('useClientRequest', () => {
         () =>
           ([fetchData, state] = useClientRequest(TEST_QUERY, {
             isManual: true
+          })),
+        {
+          wrapper: Wrapper
+        }
+      )
+      expect(fetchData).toEqual(expect.any(Function))
+      expect(state).toEqual({ cacheHit: false, loading: false })
+    })
+
+    it('sets loading to false if skip is passed in', () => {
+      let fetchData, state
+      renderHook(
+        () =>
+          ([fetchData, state] = useClientRequest(TEST_QUERY, {
+            skip: true
           })),
         {
           wrapper: Wrapper

--- a/packages/graphql-hooks/test-jsdom/unit/useQuery.test.tsx
+++ b/packages/graphql-hooks/test-jsdom/unit/useQuery.test.tsx
@@ -56,8 +56,12 @@ describe('useQuery', () => {
   })
 
   it('throws an error if not provided with an appropriate client', () => {
-    const { result } = renderHook(() => useQuery(TEST_QUERY, { useCache: true }))
-    expect(result.error?.message).toEqual('useQuery() requires a client to be passed in the options or as a context value')
+    const { result } = renderHook(() =>
+      useQuery(TEST_QUERY, { useCache: true })
+    )
+    expect(result.error?.message).toEqual(
+      'useQuery() requires a client to be passed in the options or as a context value'
+    )
   })
 
   it('calls useClientRequest with options', () => {


### PR DESCRIPTION
### What does this PR do?

The initial value of the `loading` flag should be false when `skip` option is true

### Related issues

Fixes #860 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
