### PR TITLE
Fix/930 enhance set query data

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ const client = new GraphQLClient(config)
 - `options.fetchOptionsOverrides`: Object containing additional fetch options to be added to the default ones passed to `new GraphQLClient(config)`
 - `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are merged to the `request` response under the `data` key. Example usage: `{responseReducer: (data, response) => ({...data, myKey: response.headers.get('content-length)})`
 - `client.invalidateQuery(query)`: Will delete the older cache, re-fetch the new data using the same query, and store it in the cache as a new value
-  - `query`: The GraphQL query as a plain string to be re-fetched
+  - `query`: The GraphQL query as a plain string to be re-fetched or an Operation object (with `query`, `variables` and `operationName`)
 - `client.setQueryData(query, (oldState) => [...oldState, newState]])`: Will override the older cache state with the new one provided by the function return
-  - `query`: The GraphQL query as a plain string
+  - `query`: The GraphQL query as a plain string or an Operation object (with `query`, `variables` and `operationName`)
   - `(oldState) => [...oldState, newState]]`: The callback function with returns will be the new state stored in the cache.
     - `oldState`: The old value stored in the cache
 

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ const client = new GraphQLClient(config)
 - `options.fetchOptionsOverrides`: Object containing additional fetch options to be added to the default ones passed to `new GraphQLClient(config)`
 - `options.responseReducer`: Reducer function to pick values from the original Fetch Response object. Values are merged to the `request` response under the `data` key. Example usage: `{responseReducer: (data, response) => ({...data, myKey: response.headers.get('content-length)})`
 - `client.invalidateQuery(query)`: Will delete the older cache, re-fetch the new data using the same query, and store it in the cache as a new value
-  - `query`: The GraphQL query as a plain string to be re-fetched or an Operation object (with `query`, `variables` and `operationName`)
+  - `query`: The GraphQL query as a plain string to be re-fetched, or an Operation object (with `query`, `variables` and `operationName`)
 - `client.setQueryData(query, (oldState) => [...oldState, newState]])`: Will override the older cache state with the new one provided by the function return
-  - `query`: The GraphQL query as a plain string or an Operation object (with `query`, `variables` and `operationName`)
+  - `query`: The GraphQL query as a plain string, or an Operation object (with `query`, `variables` and `operationName`)
   - `(oldState) => [...oldState, newState]]`: The callback function with returns will be the new state stored in the cache.
     - `oldState`: The old value stored in the cache
 

--- a/packages/graphql-hooks/src/GraphQLClient.ts
+++ b/packages/graphql-hooks/src/GraphQLClient.ts
@@ -413,11 +413,13 @@ class GraphQLClient {
     }
   }
 
-  invalidateQuery(query: string): void {
-    const cacheKey = this.getCacheKey({ query })
+  invalidateQuery(query: Operation | string): void {
+    const cacheKeyProp = (typeof query === 'string' ? { query } : query) as Operation
+
+    const cacheKey = this.getCacheKey(cacheKeyProp)
     if (this.cache && cacheKey) {
       this.removeCache(cacheKey)
-      this.request({ query })
+      this.request(cacheKeyProp)
         .then(result => {
           this.mutationsEmitter.emit(Events.DATA_INVALIDATED, result)
         })
@@ -425,8 +427,10 @@ class GraphQLClient {
     }
   }
 
-  setQueryData(query: string, updater: (oldState?: any) => any): void {
-    const cacheKey = this.getCacheKey({ query })
+  setQueryData(query: Operation | string, updater: (oldState?: any) => any): void {
+    const cacheKeyProp = (typeof query === 'string' ? { query } : query) as Operation
+
+    const cacheKey = this.getCacheKey(cacheKeyProp)
     if (this.cache && cacheKey) {
       const oldState: any = this.cache.get(cacheKey)
       const newState = {

--- a/packages/graphql-hooks/test-node/GraphQLClient.test.ts
+++ b/packages/graphql-hooks/test-node/GraphQLClient.test.ts
@@ -4,6 +4,7 @@ import { FormData, File } from 'formdata-node'
 import { fileFromPathSync } from 'formdata-node/file-from-path'
 import { Events } from '../src/events'
 import EventEmitter from 'events'
+import { Operation } from '../lib/types/common-types'
 
 const validConfig = {
   url: 'https://my.graphql.api'
@@ -115,6 +116,112 @@ describe('with files in Node JS', () => {
     expect(requestMock).not.toBeCalled()
   })
 
+  it('correctly uses the invalidateQuery function when using an Operation object', () => {
+    const operation = {
+      query: validQuery,
+      operationName: 'Operation'
+    }
+    
+    const client = new GraphQLClient(validConfig)
+    const mutationsEmitterMock = {
+      ...new EventEmitter(),
+      emit: jest.fn()
+    }
+    const cacheMock = {
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      keys: jest.fn(),
+      getInitialState: jest.fn()
+    }
+    const getCacheKeyMock = jest.fn(query => query)
+    const resultMock = { hello: 'World' }
+
+    client.getCacheKey = getCacheKeyMock
+    client.cache = cacheMock
+    client.request = jest.fn(() => ({
+      then: jest.fn(callback => {
+        callback(resultMock)
+        return {
+          catch: jest.fn()
+        }
+      })
+    })) as any
+    client.mutationsEmitter = mutationsEmitterMock
+
+    client.invalidateQuery(operation)
+
+    expect(getCacheKeyMock).toBeCalledTimes(1)
+    expect(getCacheKeyMock).toBeCalledWith(operation)
+
+    expect(cacheMock.delete).toBeCalledTimes(1)
+    expect(cacheMock.delete).toBeCalledWith(operation)
+
+    expect(mutationsEmitterMock.emit).toBeCalledTimes(1)
+    expect(mutationsEmitterMock.emit).toBeCalledWith(
+      Events.DATA_INVALIDATED,
+      resultMock
+    )
+  })
+
+  it('should call invalidateQuery function with variables property set on the Operations object', () => {
+    const file = fileFromPathSync(path.resolve(__dirname, './sample.txt'))
+
+    const operation = {
+      operationName: 'Operation',
+      variables: {
+        a: file,
+        b: 123,
+        c: 'test',
+        d: true
+      },
+      query: validQuery
+    }
+
+    const client = new GraphQLClient(validConfig)
+    const mutationsEmitterMock = {
+      ...new EventEmitter(),
+      emit: jest.fn()
+    }
+    const cacheMock = {
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      keys: jest.fn(),
+      getInitialState: jest.fn()
+    }
+    const getCacheKeyMock = jest.fn(query => query)
+    const resultMock = { hello: 'World' }
+
+    client.getCacheKey = getCacheKeyMock
+    client.cache = cacheMock
+    client.request = jest.fn(() => ({
+      then: jest.fn(callback => {
+        callback(resultMock)
+        return {
+          catch: jest.fn()
+        }
+      })
+    })) as any
+    client.mutationsEmitter = mutationsEmitterMock
+
+    client.invalidateQuery(operation)
+
+    expect(getCacheKeyMock).toBeCalledTimes(1)
+    expect(getCacheKeyMock).toBeCalledWith(operation)
+
+    expect(cacheMock.delete).toBeCalledTimes(1)
+    expect(cacheMock.delete).toBeCalledWith(operation)
+
+    expect(mutationsEmitterMock.emit).toBeCalledTimes(1)
+    expect(mutationsEmitterMock.emit).toBeCalledWith(
+      Events.DATA_INVALIDATED,
+      resultMock
+    )
+  })
+
   it('should call every dependency of the setQueryData function', () => {
     const client = new GraphQLClient(validConfig)
     const stateMock = { hello: 'World' }
@@ -165,5 +272,111 @@ describe('with files in Node JS', () => {
     client.setQueryData(validQuery, updaterMock)
 
     expect(updaterMock).not.toBeCalled()
+  })
+
+  it('correctly sets the query data when operationName changes (using Operation object)', () => {
+    let operation = {
+      query: validQuery,
+      operationName: 'Operation1'
+    }
+
+    const client = new GraphQLClient(validConfig)
+    const stateMock = { hello: 'World' }
+    const olderStatateMock = { data: stateMock }
+    const mutationsEmitterMock = {
+      ...new EventEmitter(),
+      emit: jest.fn()
+    }
+    const cacheMock = {
+      get: jest.fn(() => olderStatateMock),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      keys: jest.fn(),
+      getInitialState: jest.fn()
+    }
+    const getCacheKeyMock = jest.fn(query => query)
+    const resultMock = { hello: 'World' }
+    const updaterMock = jest.fn(() => resultMock)
+
+    client.getCacheKey = getCacheKeyMock
+    client.cache = cacheMock
+    client.mutationsEmitter = mutationsEmitterMock
+
+    client.setQueryData(operation, updaterMock)
+    expect(getCacheKeyMock).toBeCalledTimes(1)
+    expect(getCacheKeyMock).toBeCalledWith(operation)
+
+    operation.operationName = 'Operation2'
+
+    client.setQueryData(operation, updaterMock)
+
+    expect(getCacheKeyMock).toBeCalledTimes(2)
+    expect(getCacheKeyMock).toBeCalledWith(operation)
+
+    expect(cacheMock.get).toBeCalledTimes(2)
+    expect(cacheMock.get).toBeCalledWith(operation)
+
+    expect(updaterMock).toBeCalledTimes(2)
+    expect(updaterMock).toBeCalledWith(resultMock)
+
+    expect(mutationsEmitterMock.emit).toBeCalledTimes(2)
+    expect(mutationsEmitterMock.emit).toBeCalledWith(Events.DATA_UPDATED, {
+      data: resultMock
+    })
+  })
+
+  it('should call setQueryData function with variables property set on the Operations object', () => {
+    const file = fileFromPathSync(path.resolve(__dirname, './sample.txt'))
+
+    const operation = {
+      operationName: 'Operation',
+      variables: {
+        a: file,
+        b: 123,
+        c: 'test',
+        d: true
+      },
+      query: validQuery
+    }
+
+    const client = new GraphQLClient(validConfig)
+    const stateMock = { hello: 'World' }
+    const olderStatateMock = { data: stateMock }
+    const mutationsEmitterMock = {
+      ...new EventEmitter(),
+      emit: jest.fn()
+    }
+    const cacheMock = {
+      get: jest.fn(() => olderStatateMock),
+      set: jest.fn(),
+      delete: jest.fn(),
+      clear: jest.fn(),
+      keys: jest.fn(),
+      getInitialState: jest.fn()
+    }
+    const getCacheKeyMock = jest.fn(query => query)
+    const resultMock = { hello: 'World' }
+    const updaterMock = jest.fn(() => resultMock)
+
+    client.getCacheKey = getCacheKeyMock
+    client.cache = cacheMock
+    client.mutationsEmitter = mutationsEmitterMock
+
+    client.setQueryData(operation, updaterMock)
+
+    expect(getCacheKeyMock).toBeCalledTimes(1)
+    expect(getCacheKeyMock).toBeCalledWith(operation)
+
+    expect(cacheMock.get).toBeCalledTimes(1)
+    expect(cacheMock.get).toBeCalledWith(operation)
+
+    expect(updaterMock).toBeCalledTimes(1)
+    expect(updaterMock).toBeCalledWith(resultMock)
+
+    expect(mutationsEmitterMock.emit).toBeCalledTimes(1)
+    expect(mutationsEmitterMock.emit).toBeCalledWith(Events.DATA_UPDATED, {
+      data: resultMock
+    })
   })
 })


### PR DESCRIPTION
This PR will enable the setQueryData and invalidateQuery functions to receive operation object when being called.
Backward compatibility is met because we have changed the definition of these functions.

Closes: https://github.com/nearform/graphql-hooks/issues/930