### PR TITLE
Continue execution if errors occur in APQ middleware

### DIFF
--- a/packages/graphql-hooks/src/middlewares/apqMiddleware.ts
+++ b/packages/graphql-hooks/src/middlewares/apqMiddleware.ts
@@ -74,7 +74,7 @@ export const APQMiddleware: MiddlewareFunction<APQExtension> = async (
     if (isPersistedQueryNotFound(error)) {
       next()
     } else {
-      throw error
+      resolve(res);
     }
   } catch (err: any) {
     reject(err)


### PR DESCRIPTION
If GraphQL returns an error, all further execution is halted. But the handling of those errors should not be done by the middleware.

### What does this PR do?

Fix a bug where if GraphQL returns data and errors, the further execution is completely halted and the error is thrown too soon.

### Checklist

- [ x ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ x ] I have added or updated any relevant documentation
- [ x ] I have added or updated any relevant tests
