### PR TITLE
fix: add node option --openssl-legacy-provider to fix rollup builds

### DIFF
--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rm -rf ./dist ./es ./lib",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rollup -c",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider rollup -c",
     "prepublishOnly": "npm run build && cp ../../LICENSE ."
   },
   "files": [

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rm -rf ./dist ./es ./lib",
     "build": "npm run build:code && npm run build:types",
-    "build:code": "rollup -c",
+    "build:code": "NODE_OPTIONS=--openssl-legacy-provider rollup -c",
     "build:types": "tsc --emitDeclarationOnly --declaration",
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build && cp ../../README.md . && cp ../../LICENSE ."


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of what this pull request is for, please provide any background -->

This morning the Netlify configuration has been updated to use node 18. This generates the following error during the build phase:

```
11:31:27 AM: src/index.js → es/graphql-hooks-memcache.js...
11:31:27 AM: Error: error:0308010C:digital envelope routines::unsupported
11:31:27 AM:     at new Hash (node:internal/crypto/hash:71:19)
11:31:27 AM:     at Object.createHash (node:crypto:133:10)
11:31:27 AM:     at module.exports (/opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/lib/util/createHash.js:135:53)
11:31:27 AM:     at NormalModule._initBuildHash (/opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/lib/NormalModule.js:417:16)
11:31:27 AM:     at handleParseError (/opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/lib/NormalModule.js:471:10)
11:31:27 AM:     at /opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/lib/NormalModule.js:503:5
11:31:27 AM:     at /opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/webpack/lib/NormalModule.js:358:12
11:31:27 AM:     at /opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/loader-runner/lib/LoaderRunner.js:373:3
11:31:27 AM:     at iterateNormalLoaders (/opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
11:31:27 AM:     at /opt/build/repo/node_modules/rollup-plugin-size-snapshot/node_modules/loader-runner/lib/LoaderRunner.js:205:4
11:31:27 AM:     at Immediate.<anonymous> (/opt/build/repo/node_modules/memory-fs/lib/MemoryFileSystem.js:330:4)
11:31:27 AM:     at processImmediate (node:internal/timers:471:21)
```

Based on [this article](https://www.newline.co/@kchan/how-to-fix-the-error-errorerror0308010cdigital-envelope-routinesunsupported--0f8d3f17):

> With Node.js v17+ supporting OpenSSL 3.0, algorithms like MD4 have been relegated to OpenSSL 3.0’s legacy provider. A provider is a collection of cryptographic algorithm implementations. OpenSSL 3.0 comes with [five standard providers](https://wiki.openssl.org/index.php/OpenSSL_3.0#Upgrading_to_OpenSSL_3.0_from_OpenSSL_1.0.2#Providers): default, legacy, FIPS, base and null. The legacy provider consists of algorithms that are considered to be rarely used in today’s world or unsafe security-wise. This provider exists for backwards compatibility purposes (for software that still rely on these algorithms) and is not loaded by default.
> 
> Webpack creates hashes using the [crypto.createHash()](https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options) method of the Node.js [crypto](https://nodejs.org/api/crypto.html) module. This method can only create hashes with algorithms that are available and supported by the version of OpenSSL corresponding to the currently installed Node.js version. Since Webpack specifies to the crypto.createHash() method to use the MD4 algorithm (see below code), and this algorithm is not readily available in Node.js v17+ due to OpenSSL 3.0 not loading legacy providers by default, Webpack errors out and Node.js logs the error message `Error: error:0308010C:digital envelope routines::unsupported.`

To fix that I set the node option `--openssl-legacy-provider` before running rollup (this tells Node.js to revert to OpenSSL 3.0's legacy provider). This workaround is suggested both:
- in the article above and
- in the Webpack issue [nodejs 17: digital envelope routines::unsupported ](https://github.com/webpack/webpack/issues/14532#issuecomment-947012063). 

Please note we are already using the latest version of Webpack (`5.74.0`) and it's not fixed yet, for this reason I choose this solution.

### Related issues

<!-- Link to any related issues here -->

### Checklist

- [X] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
