### PR TITLE
Fix RefetchAfterMutationsData type's array part (#984)

### DIFF
--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -186,9 +186,8 @@ export type RefetchAfterMutationItem = {
 
 export type RefetchAfterMutationsData =
   | string
-  | string[]
   | RefetchAfterMutationItem
-  | RefetchAfterMutationItem[]
+  | (string | RefetchAfterMutationItem)[]
 
 export interface UseQueryOptions<ResponseData = any, Variables = object>
   extends UseClientRequestOptions<ResponseData, Variables> {


### PR DESCRIPTION
The type for RefetchAfterMutationsData should allow an array with a mixture of `string`s and `RefetchAfterMutationItem`s, not just an array of one or an array of the other. This makes the array part include a union of those types.

### What does this PR do?

This PR fixes the type for RefetchAfterMutationsData.

### Related issues

Fixes #984 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
