### PR TITLE
Use `any` for RefetchAfterMutationItem filter param (#986)

### DIFF
--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -181,7 +181,7 @@ export interface UseClientRequestOptions<
 
 export type RefetchAfterMutationItem = {
   mutation: string
-  filter?: (variables: object) => boolean
+  filter?: (variables: any) => boolean
 }
 
 export type RefetchAfterMutationsData =


### PR DESCRIPTION
With `object` as the type, it's cumbersome to type it correctly (can't pass a type parameter, can't just index on it, have to use a typecast in the function body). This commit makes it so we just use any as the variables type, as that is actually more what we want. From our perspective, we pass `filter` a parameter and want a boolean back.

### What does this PR do?

Changes the type for the param to RefetchAfterMutationItem["filter"] to `any` so it can be used without doing a type cast in the function body.

### Related issues

Fixes #986

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
