### PR TITLE
fix: removed src folder from graphql-hooks and graphql-hooks-memcache package.json files entry

### DIFF
--- a/packages/graphql-hooks-memcache/package.json
+++ b/packages/graphql-hooks-memcache/package.json
@@ -16,7 +16,6 @@
     "dist",
     "es",
     "lib",
-    "src",
     "index.d.ts"
   ],
   "keywords": [

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -18,7 +18,6 @@
     "dist",
     "es",
     "lib",
-    "src",
     "index.d.ts"
   ],
   "keywords": [


### PR DESCRIPTION
### What does this PR do?

This PR does not ship any `src` directories, to prevent TS files parsing errors. It resolves #991 since we don't have any reproducible example.

### Related issues

#991 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
