### PR TITLE
feat: refetch a query only if mutation doesn't fail (refetchAfterMutation option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ This is a custom hook that takes care of fetching your query and storing the res
     - If it's a string, it's the mutation string
     - If it's an object then it has properties mutation and filter
       - `mutation`: String - The mutation string
-      - `refetchOnMutationError`: boolean (optional, fallback to `true`) - It indicates whether the query must be re-fetched due to a mutation error
+      - `refetchOnMutationError`: boolean (optional, fallback to `true`) - It indicates whether the query must be re-fetched if the mutation returns an error
       - `filter`: Function (optional) - It receives mutation's variables as parameter and blocks refetch if it returns false
     - If it's an array, the elements can be of either type above
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ This is a custom hook that takes care of fetching your query and storing the res
     - If it's a string, it's the mutation string
     - If it's an object then it has properties mutation and filter
       - `mutation`: String - The mutation string
-      - `refetchOnMutationError`: boolean (optional, fallback to `true`) - It indicates whether the query must be re-fetched if the mutation returns an error
+      - `refetchOnMutationError`: boolean (optional, defaults to `true`) - It indicates whether the query must be re-fetched if the mutation returns an error
       - `filter`: Function (optional) - It receives mutation's variables as parameter and blocks refetch if it returns false
     - If it's an array, the elements can be of either type above
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ This is a custom hook that takes care of fetching your query and storing the res
     - If it's a string, it's the mutation string
     - If it's an object then it has properties mutation and filter
       - `mutation`: String - The mutation string
+      - `refetchOnMutationError`: boolean (optional, fallback to `true`) - It indicates whether the query must be re-fetched due to a mutation error
       - `filter`: Function (optional) - It receives mutation's variables as parameter and blocks refetch if it returns false
     - If it's an array, the elements can be of either type above
 

--- a/packages/graphql-hooks/src/createRefetchMutationsMap.js
+++ b/packages/graphql-hooks/src/createRefetchMutationsMap.js
@@ -19,13 +19,11 @@ export default function createRefetchMutationsMap(refetchAfterMutations) {
     if (paramType === 'string') {
       result[mutationInfo] = {}
     } else if (paramType === 'object') {
-      const { filter, mutation, refetchOnMutationError } = mutationInfo
+      const { filter, mutation, refetchOnMutationError = true } = mutationInfo
 
       result[mutation] = {
         filter,
-        refetchOnMutationError:
-          typeof refetchOnMutationError === 'undefined' ||
-          refetchOnMutationError
+        refetchOnMutationError
       }
     }
   })

--- a/packages/graphql-hooks/src/createRefetchMutationsMap.js
+++ b/packages/graphql-hooks/src/createRefetchMutationsMap.js
@@ -19,9 +19,14 @@ export default function createRefetchMutationsMap(refetchAfterMutations) {
     if (paramType === 'string') {
       result[mutationInfo] = {}
     } else if (paramType === 'object') {
-      const { filter, mutation } = mutationInfo
+      const { filter, mutation, refetchOnMutationError } = mutationInfo
 
-      result[mutation] = { filter }
+      result[mutation] = {
+        filter,
+        refetchOnMutationError:
+          typeof refetchOnMutationError === 'undefined' ||
+          refetchOnMutationError
+      }
     }
   })
 

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -176,11 +176,15 @@ export interface UseClientRequestOptions<
   client?: GraphQLClient
   responseReducer?(data: object, response: object): object
   persisted?: boolean
-  onSuccess?(result: Result<ResponseData, TGraphQLError>, variables: Variables): void
+  onSuccess?(
+    result: Result<ResponseData, TGraphQLError>,
+    variables: Variables
+  ): void
 }
 
 export type RefetchAfterMutationItem = {
   mutation: string
+  refetchOnMutationError?: boolean
   filter?: (variables: any) => boolean
 }
 

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -79,22 +79,28 @@ function useQuery<
       const mutationsMap = createRefetchMutationsMap(opts.refetchAfterMutations)
       const mutations = Object.keys(mutationsMap)
 
-      const conditionalRefetch = ({ mutation, variables }) => {
+      const afterConditionsCheckRefetch = ({ mutation, variables, result }) => {
         const { filter } = mutationsMap[mutation]
 
-        if (!filter || (variables && filter(variables))) {
+        const hasValidFilterOrNoFilter =
+          !filter || (variables && filter(variables))
+
+        if (hasValidFilterOrNoFilter && !result.error) {
           refetch()
         }
       }
 
       mutations.forEach(mutation => {
         // this event is emitted from useClientRequest
-        client.mutationsEmitter.on(mutation, conditionalRefetch)
+        client.mutationsEmitter.on(mutation, afterConditionsCheckRefetch)
       })
 
       return () => {
         mutations.forEach(mutation => {
-          client.mutationsEmitter.removeListener(mutation, conditionalRefetch)
+          client.mutationsEmitter.removeListener(
+            mutation,
+            afterConditionsCheckRefetch
+          )
         })
       }
     },

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -80,12 +80,14 @@ function useQuery<
       const mutations = Object.keys(mutationsMap)
 
       const afterConditionsCheckRefetch = ({ mutation, variables, result }) => {
-        const { filter } = mutationsMap[mutation]
+        const { filter, refetchOnMutationError } = mutationsMap[mutation]
 
         const hasValidFilterOrNoFilter =
           !filter || (variables && filter(variables))
 
-        if (hasValidFilterOrNoFilter && !result.error) {
+        const shouldRefetch = refetchOnMutationError || !result.error
+
+        if (hasValidFilterOrNoFilter && shouldRefetch) {
           refetch()
         }
       }

--- a/packages/graphql-hooks/test-jsdom/unit/createRefetchMutationsMap.test.ts
+++ b/packages/graphql-hooks/test-jsdom/unit/createRefetchMutationsMap.test.ts
@@ -13,7 +13,7 @@ describe('createRefetchMutationsMap', () => {
     const result = createRefetchMutationsMap({ mutation: 'my-mutation' })
 
     expect(result).toEqual({
-      'my-mutation': {}
+      'my-mutation': { refetchOnMutationError: true }
     })
   })
 
@@ -26,9 +26,9 @@ describe('createRefetchMutationsMap', () => {
     ])
 
     expect(result).toEqual({
-      'my-mutation': {},
+      'my-mutation': { refetchOnMutationError: true },
       'my-mutation-2': {},
-      'my-mutation-3': { filter }
+      'my-mutation-3': { filter, refetchOnMutationError: true }
     })
   })
 
@@ -41,7 +41,7 @@ describe('createRefetchMutationsMap', () => {
     ])
 
     expect(result).toEqual({
-      'my-mutation': {}
+      'my-mutation': { refetchOnMutationError: true }
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
With this PR, a query is refetched only if the relative mutation (linked using `refetchAfterMutation` option) is successful.
I also renamed `conditionalRefetch` to `afterConditionsCheckRefetch` since it's not only a conditional refetch anymore, it also check for errors.

Introduced `refetchAfterMutations` as an optional parameter in [RefetchAfterMutationItem](https://github.com/nearform/graphql-hooks/pull/993/files#diff-d1d76b2c9ec609544e715dedb4b77efe053d6798016eeebc562a64dd3765cc79R187) type to determine whether or not to refetch the query if the mutation fails.

<!-- A brief description of what this pull request is for, please provide any background -->

### Related issues

It resolves #988.

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
