### PR TITLE
973 / Fix APIError Type

### DIFF
--- a/packages/graphql-hooks/src/GraphQLClient.ts
+++ b/packages/graphql-hooks/src/GraphQLClient.ts
@@ -2,24 +2,24 @@ import EventEmitter from 'events'
 import { extractFiles } from 'extract-files'
 import { Client as GraphQLWsClient } from 'graphql-ws'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
-import canUseDOM from './canUseDOM'
-import isExtractableFileEnhanced from './isExtractableFileEnhanced'
 import Middleware from './Middleware'
+import canUseDOM from './canUseDOM'
+import { Events } from './events'
+import isExtractableFileEnhanced from './isExtractableFileEnhanced'
 import type {
-  UseClientRequestOptions,
   Cache,
+  CacheKeyObject,
   ClientOptions,
   FetchFunction,
   GenerateResultOptions,
+  GraphQLResponseError,
   OnErrorFunction,
   Operation,
   RequestOptions,
   Result,
-  GraphQLResponseError,
-  CacheKeyObject
+  UseClientRequestOptions
 } from './types/common-types'
 import { pipeP } from './utils'
-import { Events } from './events'
 
 class GraphQLClient {
   url: string
@@ -414,7 +414,9 @@ class GraphQLClient {
   }
 
   invalidateQuery(query: Operation | string): void {
-    const cacheKeyProp = (typeof query === 'string' ? { query } : query) as Operation
+    const cacheKeyProp = (
+      typeof query === 'string' ? { query } : query
+    ) as Operation
 
     const cacheKey = this.getCacheKey(cacheKeyProp)
     if (this.cache && cacheKey) {
@@ -427,8 +429,13 @@ class GraphQLClient {
     }
   }
 
-  setQueryData(query: Operation | string, updater: (oldState?: any) => any): void {
-    const cacheKeyProp = (typeof query === 'string' ? { query } : query) as Operation
+  setQueryData(
+    query: Operation | string,
+    updater: (oldState?: any) => any
+  ): void {
+    const cacheKeyProp = (
+      typeof query === 'string' ? { query } : query
+    ) as Operation
 
     const cacheKey = this.getCacheKey(cacheKeyProp)
     if (this.cache && cacheKey) {

--- a/packages/graphql-hooks/src/LocalGraphQLError.ts
+++ b/packages/graphql-hooks/src/LocalGraphQLError.ts
@@ -3,14 +3,12 @@ import { APIError, GraphQLResponseError, HttpError } from './types/common-types'
 /** Used to easily mock a query returning an error when using the `LocalGraphQLClient`.
  * This is a class so that the local mock client can use `instanceof` to detect it.
  */
-class LocalGraphQLError<TGraphQLError = GraphQLResponseError>
-  implements APIError<TGraphQLError>
-{
+class LocalGraphQLError implements APIError {
   fetchError?: Error
   httpError?: HttpError
   graphQLErrors?: GraphQLResponseError[]
 
-  constructor(error: APIError<TGraphQLError>) {
+  constructor(error: APIError) {
     this.fetchError = error.fetchError
     this.httpError = error.httpError
     this.graphQLErrors = error.graphQLErrors

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -71,10 +71,8 @@ export interface LocalClientOptions extends Omit<ClientOptions, 'url'> {
   url?: string
 }
 
-declare class LocalGraphQLError<TGraphQLError = object>
-  implements APIError<TGraphQLError>
-{
-  constructor(error: APIError<TGraphQLError>)
+declare class LocalGraphQLError implements APIError {
+  constructor(error: APIError)
 }
 
 export interface SubscriptionRequest {
@@ -127,10 +125,10 @@ export interface HttpError {
   body: string
 }
 
-export interface APIError<TGraphQLError = GraphQLResponseError> {
+export interface APIError {
   fetchError?: Error
   httpError?: HttpError
-  graphQLErrors?: TGraphQLError[]
+  graphQLErrors?: GraphQLResponseError[]
 }
 
 export interface Result<
@@ -138,7 +136,7 @@ export interface Result<
   TGraphQLError = GraphQLResponseError
 > {
   data?: ResponseData
-  error?: APIError<TGraphQLError>
+  error?: APIError
 }
 
 export interface RequestOptions {
@@ -206,7 +204,7 @@ export interface UseClientRequestResult<
   cacheHit: boolean
   cacheKey?: CacheKeyObject
   data?: ResponseData
-  error?: APIError<TGraphQLError>
+  error?: APIError
 }
 
 export interface UseQueryResult<

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -1,6 +1,4 @@
-import EventEmitter from 'events'
 import { Client as GraphQLWsClient } from 'graphql-ws'
-import * as React from 'react'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
 import GraphQLClient from '../GraphQLClient'
 // Exports
@@ -129,10 +127,10 @@ export interface HttpError {
   body: string
 }
 
-export interface APIError<TGraphQLError = object> {
+export interface APIError<TGraphQLError = GraphQLResponseError> {
   fetchError?: Error
   httpError?: HttpError
-  graphQLErrors?: GraphQLResponseError[]
+  graphQLErrors?: TGraphQLError[]
 }
 
 export interface Result<


### PR DESCRIPTION
Remove the unused generic type `TGraphQLError` within the interface 

### Related issues

fixes #973 

Spent a bit of time today trying to update this generic but found myself facing issues with types further down the chain where we are specifying `any` or `object` such as in: https://github.com/nearform/graphql-hooks/blob/master/packages/graphql-hooks/src/GraphQLClient.ts#L157

In the end I decided it was easier for this particular issue to just remove the unused generic. But I wonder if we may want another issue opening to type these other areas more strongly rather than relying on `any` and `object`.

### Checklist

- [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
