### PR TITLE
docs: update "not yet supported" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,6 @@ A lot of options can be carried over as-is, or have direct replacements:
 - `errorPolicy`: Any error will set the `error` to be truthy. See [useQuery](#useQuery) for more details.
 - `pollInterval`
 - `notifyOnNetworkStatusChange`
-- `skip`
 - `onCompleted`: Similar ability if using `useManualQuery`
 - `onError`: Similar ability if using `useManualQuery`
 - `partialRefetch`


### PR DESCRIPTION
### What does this PR do?

According to #663 and other parts of the documentation, `skip` seems to be a supported option for `useQuery`.

### Related issues

#663 

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
