### PR TITLE
fix: #1007 client.mutationsEmmiter.off is not a function

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -295,14 +295,18 @@ function useClientRequest<
     const dataUpdatedCallback = payload =>
       handleEvents(payload, actionTypes.CACHE_HIT)
 
-    client.mutationsEmitter.on(Events.DATA_INVALIDATED, dataInvalidatedCallback)
-    client.mutationsEmitter.on(Events.DATA_UPDATED, dataUpdatedCallback)
+    const mutationsEmitter = client.mutationsEmitter
+    mutationsEmitter.on(Events.DATA_INVALIDATED, dataInvalidatedCallback)
+    mutationsEmitter.on(Events.DATA_UPDATED, dataUpdatedCallback)
+
     return () => {
-      client.mutationsEmitter.off(
-        Events.DATA_INVALIDATED,
-        dataInvalidatedCallback
-      )
-      client.mutationsEmitter.off(Events.DATA_UPDATED, dataUpdatedCallback)
+      if(mutationsEmitter){
+        mutationsEmitter.removeListener(
+          Events.DATA_INVALIDATED,
+          dataInvalidatedCallback
+        )
+        mutationsEmitter.removeListener(Events.DATA_UPDATED, dataUpdatedCallback)
+      }
     }
   }, [])
 

--- a/packages/graphql-hooks/test-jsdom/unit/useClientRequest.test.tsx
+++ b/packages/graphql-hooks/test-jsdom/unit/useClientRequest.test.tsx
@@ -32,7 +32,7 @@ describe('useClientRequest', () => {
       mutationsEmitter: {
         emit: jest.fn(),
         on: jest.fn(),
-        off: jest.fn(),
+        removeListener: jest.fn(),
       },
       getCacheKey: jest.fn().mockReturnValue('cacheKey'),
       getCache: jest.fn(),
@@ -59,7 +59,7 @@ describe('useClientRequest', () => {
       mutationsEmitter: {
         emit: jest.fn(),
         on: jest.fn(),
-        off: jest.fn(),
+        removeListener: jest.fn(),
       },
       getCacheKey: jest.fn().mockReturnValue('cacheKey'),
       getCache: jest.fn(),
@@ -850,7 +850,7 @@ describe('useClientRequest', () => {
         mutationsEmitter: {
           emit: jest.fn(),
           on: jest.fn(),
-          off: jest.fn(),
+          removeListener: jest.fn(),
         },
         getCacheKey: jest.fn().mockReturnValue('cacheKey'),
         getCache: jest.fn(),
@@ -915,7 +915,7 @@ describe('useClientRequest', () => {
       mutationsEmitter: {
         emit: jest.fn(),
         on: jest.fn(),
-        off: jest.fn(),
+        removeListener: jest.fn(),
       },
       getCacheKey: jest.fn().mockReturnValue('cacheKey'),
       getCache: jest.fn(),
@@ -942,11 +942,11 @@ describe('useClientRequest', () => {
 
     unmount()
 
-    expect(mockClient.mutationsEmitter.off).toHaveBeenCalledTimes(2)
-    expect(mockClient.mutationsEmitter.off).toHaveBeenNthCalledWith(1, "DATA_INVALIDATED", expect.any(Function))
-    expect(mockClient.mutationsEmitter.off).toHaveBeenNthCalledWith(2, "DATA_UPDATED", expect.any(Function))
+    expect(mockClient.mutationsEmitter.removeListener).toHaveBeenCalledTimes(2)
+    expect(mockClient.mutationsEmitter.removeListener).toHaveBeenNthCalledWith(1, "DATA_INVALIDATED", expect.any(Function))
+    expect(mockClient.mutationsEmitter.removeListener).toHaveBeenNthCalledWith(2, "DATA_UPDATED", expect.any(Function))
 
-    expect(mockClient.mutationsEmitter.on.mock.calls[0][1]).toBe(mockClient.mutationsEmitter.off.mock.calls[0][1])
-    expect(mockClient.mutationsEmitter.on.mock.calls[1][1]).toBe(mockClient.mutationsEmitter.off.mock.calls[1][1])
+    expect(mockClient.mutationsEmitter.on.mock.calls[0][1]).toBe(mockClient.mutationsEmitter.removeListener.mock.calls[0][1])
+    expect(mockClient.mutationsEmitter.on.mock.calls[1][1]).toBe(mockClient.mutationsEmitter.removeListener.mock.calls[1][1])
   })
 })


### PR DESCRIPTION
Closes: #1007 

For some reasons the `.off` function was not part of the event emitter in the authors environment, before putting the PR out of WIP need more details from the ticket author, to verify this was the actual problem.
