### PR TITLE
chore: ensure generic error type is used in apierror interface

### DIFF
--- a/packages/graphql-hooks/src/LocalGraphQLClient.ts
+++ b/packages/graphql-hooks/src/LocalGraphQLClient.ts
@@ -1,6 +1,6 @@
 import GraphQLClient from './GraphQLClient'
 import LocalGraphQLError from './LocalGraphQLError'
-import { LocalClientOptions, LocalQueries } from './types/common-types'
+import { LocalClientOptions, LocalQueries, Result } from './types/common-types';
 
 /** Local version of the GraphQLClient which only returns specified queries
  * Meant to be used as a way to easily mock and test queries during development. This client never contacts any actual server.
@@ -41,7 +41,7 @@ class LocalGraphQLClient extends GraphQLClient {
     // Skips all config verification from the parent class because we're mocking the client
   }
 
-  request(operation) {
+  request<ResponseData = any, TGraphQLError = object, TVariables = object>(operation): Promise<Result<any, TGraphQLError>> {
     if (!this.localQueries[operation.query]) {
       throw new Error(
         `LocalGraphQLClient: no query match for: ${operation.query}`
@@ -57,7 +57,7 @@ class LocalGraphQLClient extends GraphQLClient {
         )
       )
       .then(result => {
-        if (result instanceof LocalGraphQLError) {
+        if (result instanceof LocalGraphQLError<TGraphQLError>) {
           return { error: result }
         }
         return { data: result }

--- a/packages/graphql-hooks/src/LocalGraphQLError.ts
+++ b/packages/graphql-hooks/src/LocalGraphQLError.ts
@@ -1,14 +1,14 @@
-import { APIError, GraphQLResponseError, HttpError } from './types/common-types'
+import { APIError, HttpError } from './types/common-types'
 
 /** Used to easily mock a query returning an error when using the `LocalGraphQLClient`.
  * This is a class so that the local mock client can use `instanceof` to detect it.
  */
-class LocalGraphQLError<TGraphQLError = GraphQLResponseError>
+class LocalGraphQLError<TGraphQLError = object>
   implements APIError<TGraphQLError>
 {
   fetchError?: Error
   httpError?: HttpError
-  graphQLErrors?: GraphQLResponseError[]
+  graphQLErrors?: TGraphQLError[]
 
   constructor(error: APIError<TGraphQLError>) {
     this.fetchError = error.fetchError

--- a/packages/graphql-hooks/src/middlewares/apqMiddleware.ts
+++ b/packages/graphql-hooks/src/middlewares/apqMiddleware.ts
@@ -1,6 +1,6 @@
 import { Sha256 } from '@aws-crypto/sha256-browser'
 import { Buffer } from 'buffer'
-import { APIError, MiddlewareFunction } from '../types/common-types'
+import { APIError, MiddlewareFunction, GraphQLResponseError } from '../types/common-types'
 
 export async function sha256(query) {
   const hash = new Sha256()
@@ -18,7 +18,7 @@ type APQExtension = {
   }
 }
 
-function isPersistedQueryNotFound(error: APIError) {
+function isPersistedQueryNotFound(error: APIError<GraphQLResponseError>) {
   if ((error?.fetchError as any)?.type === 'PERSISTED_QUERY_NOT_FOUND') {
     return true
   }
@@ -56,7 +56,7 @@ export const APQMiddleware: MiddlewareFunction<APQExtension> = async (
     }
 
     // Try to send just the hash
-    const res = await client.requestViaHttp(
+    const res = await client.requestViaHttp<any, GraphQLResponseError>(
       { ...operation, query: null },
       {
         fetchOptionsOverrides: { method: 'GET' }

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -22,12 +22,12 @@ export type FetchFunction = (
   init?: RequestInit
 ) => Promise<Response>
 
-export type OnErrorFunction<TVariables = any> = ({
+export type OnErrorFunction<ResponseData = any, TGraphQLError = GraphQLResponseError, TVariables = any> = ({
   result,
   operation
 }: {
   operation: Operation<TVariables>
-  result: Result
+  result: Result<ResponseData, TGraphQLError>
 }) => void
 
 export type MiddlewareOptions<T> = {
@@ -132,7 +132,7 @@ export interface HttpError {
 export interface APIError<TGraphQLError = object> {
   fetchError?: Error
   httpError?: HttpError
-  graphQLErrors?: GraphQLResponseError[]
+  graphQLErrors?: TGraphQLError[]
 }
 
 export interface Result<

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -13,17 +13,17 @@ const defaultOpts = {
 
 function useQuery<
   ResponseData = any,
-  Variables = object,
+  TVariables = object,
   TGraphQLError = object
 >(
   query: string,
-  opts: UseQueryOptions<ResponseData, Variables> = {}
-): UseQueryResult<ResponseData, Variables, TGraphQLError> {
+  opts: UseQueryOptions<ResponseData, TVariables> = {}
+): UseQueryResult<ResponseData, TVariables, TGraphQLError> {
   const allOpts = { ...defaultOpts, ...opts }
   const contextClient = React.useContext(ClientContext)
   const client = opts.client || contextClient
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false)
-  const [queryReq, state] = useClientRequest(query, allOpts)
+  const [queryReq, state] = useClientRequest<ResponseData, TVariables, TGraphQLError>(query, allOpts)
 
   if (!client) {
     throw new Error(

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -13,17 +13,17 @@ const defaultOpts = {
 
 function useQuery<
   ResponseData = any,
-  TVariables = object,
+  Variables = object,
   TGraphQLError = object
 >(
   query: string,
-  opts: UseQueryOptions<ResponseData, TVariables> = {}
-): UseQueryResult<ResponseData, TVariables, TGraphQLError> {
+  opts: UseQueryOptions<ResponseData, Variables> = {}
+): UseQueryResult<ResponseData, Variables, TGraphQLError> {
   const allOpts = { ...defaultOpts, ...opts }
   const contextClient = React.useContext(ClientContext)
   const client = opts.client || contextClient
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false)
-  const [queryReq, state] = useClientRequest<ResponseData, TVariables, TGraphQLError>(query, allOpts)
+  const [queryReq, state] = useClientRequest<ResponseData, Variables, TGraphQLError>(query, allOpts)
 
   if (!client) {
     throw new Error(


### PR DESCRIPTION
### What does this PR do?

Ensures the `TGraphQLError` type is used in the `APIError` generic interface, allowing lib users to change the `graphQLErrors` property type if needed.

This change **should not** break compatibility with previous releases or any change visible to the end user. The `typescript-example` app ran fine with the libs compiled after changes.

I don't believe new documentation or tests are relevant for these changes.

### Related issues

closes https://github.com/nearform/graphql-hooks/issues/973

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
