### PR TITLE
Convert an iterator to an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 graphql-hooks-*.*.*.tgz
 coverage

--- a/packages/graphql-hooks-memcache/src/index.js
+++ b/packages/graphql-hooks-memcache/src/index.js
@@ -38,9 +38,9 @@ export default function memCache({
     },
     delete: keyObj => lru.delete(generateKey(keyObj)),
     clear: () => lru.clear(),
-    keys: () => lru.keys(),
+    keys: () => [...lru.keys()],
     getInitialState: () =>
-      lru.keys().reduce(
+      [...lru.keys()].reduce(
         (initialState, key) => ({
           ...initialState,
           [key]: lru.get(key)

--- a/packages/graphql-hooks/src/GraphQLClient.ts
+++ b/packages/graphql-hooks/src/GraphQLClient.ts
@@ -290,7 +290,10 @@ class GraphQLClient {
           }
 
           if (this.url) {
-            return this.requestViaHttp<ResponseData, TGraphQLError, TVariables>(updatedOperation, options)
+            return this.requestViaHttp<ResponseData, TGraphQLError, TVariables>(
+              updatedOperation,
+              options
+            )
               .then(transformResponse)
               .then(resolve)
               .catch(reject)
@@ -364,7 +367,13 @@ class GraphQLClient {
           }
 
           if (this.onError) {
-            (this.onError as OnErrorFunction<ResponseData, TGraphQLError, TVariables>)({ result, operation })
+            ;(
+              this.onError as OnErrorFunction<
+                ResponseData,
+                TGraphQLError,
+                TVariables
+              >
+            )({ result, operation })
           }
         }
         return result
@@ -414,7 +423,9 @@ class GraphQLClient {
   }
 
   invalidateQuery(query: Operation | string): void {
-    const cacheKeyProp = (typeof query === 'string' ? { query } : query) as Operation
+    const cacheKeyProp = (
+      typeof query === 'string' ? { query } : query
+    ) as Operation
 
     const cacheKey = this.getCacheKey(cacheKeyProp)
     if (this.cache && cacheKey) {
@@ -427,8 +438,13 @@ class GraphQLClient {
     }
   }
 
-  setQueryData(query: Operation | string, updater: (oldState?: any) => any): void {
-    const cacheKeyProp = (typeof query === 'string' ? { query } : query) as Operation
+  setQueryData(
+    query: Operation | string,
+    updater: (oldState?: any) => any
+  ): void {
+    const cacheKeyProp = (
+      typeof query === 'string' ? { query } : query
+    ) as Operation
 
     const cacheKey = this.getCacheKey(cacheKeyProp)
     if (this.cache && cacheKey) {

--- a/packages/graphql-hooks/src/LocalGraphQLClient.ts
+++ b/packages/graphql-hooks/src/LocalGraphQLClient.ts
@@ -1,6 +1,6 @@
 import GraphQLClient from './GraphQLClient'
 import LocalGraphQLError from './LocalGraphQLError'
-import { LocalClientOptions, LocalQueries, Result } from './types/common-types';
+import { LocalClientOptions, LocalQueries, Result } from './types/common-types'
 
 /** Local version of the GraphQLClient which only returns specified queries
  * Meant to be used as a way to easily mock and test queries during development. This client never contacts any actual server.
@@ -41,7 +41,9 @@ class LocalGraphQLClient extends GraphQLClient {
     // Skips all config verification from the parent class because we're mocking the client
   }
 
-  request<ResponseData = any, TGraphQLError = object, TVariables = object>(operation): Promise<Result<any, TGraphQLError>> {
+  request<ResponseData = any, TGraphQLError = object, TVariables = object>(
+    operation
+  ): Promise<Result<any, TGraphQLError>> {
     if (!this.localQueries[operation.query]) {
       throw new Error(
         `LocalGraphQLClient: no query match for: ${operation.query}`

--- a/packages/graphql-hooks/src/middlewares/apqMiddleware.ts
+++ b/packages/graphql-hooks/src/middlewares/apqMiddleware.ts
@@ -1,6 +1,10 @@
 import { Sha256 } from '@aws-crypto/sha256-browser'
 import { Buffer } from 'buffer'
-import { APIError, MiddlewareFunction, GraphQLResponseError } from '../types/common-types'
+import {
+  APIError,
+  MiddlewareFunction,
+  GraphQLResponseError
+} from '../types/common-types'
 
 export async function sha256(query) {
   const hash = new Sha256()

--- a/packages/graphql-hooks/src/types/common-types.ts
+++ b/packages/graphql-hooks/src/types/common-types.ts
@@ -22,7 +22,11 @@ export type FetchFunction = (
   init?: RequestInit
 ) => Promise<Response>
 
-export type OnErrorFunction<ResponseData = any, TGraphQLError = GraphQLResponseError, TVariables = any> = ({
+export type OnErrorFunction<
+  ResponseData = any,
+  TGraphQLError = GraphQLResponseError,
+  TVariables = any
+> = ({
   result,
   operation
 }: {

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -300,12 +300,15 @@ function useClientRequest<
     mutationsEmitter.on(Events.DATA_UPDATED, dataUpdatedCallback)
 
     return () => {
-      if(mutationsEmitter){
+      if (mutationsEmitter) {
         mutationsEmitter.removeListener(
           Events.DATA_INVALIDATED,
           dataInvalidatedCallback
         )
-        mutationsEmitter.removeListener(Events.DATA_UPDATED, dataUpdatedCallback)
+        mutationsEmitter.removeListener(
+          Events.DATA_UPDATED,
+          dataUpdatedCallback
+        )
       }
     }
   }, [])

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -23,7 +23,11 @@ function useQuery<
   const contextClient = React.useContext(ClientContext)
   const client = opts.client || contextClient
   const [calledDuringSSR, setCalledDuringSSR] = React.useState(false)
-  const [queryReq, state] = useClientRequest<ResponseData, Variables, TGraphQLError>(query, allOpts)
+  const [queryReq, state] = useClientRequest<
+    ResponseData,
+    Variables,
+    TGraphQLError
+  >(query, allOpts)
 
   if (!client) {
     throw new Error(

--- a/packages/graphql-hooks/test-node/GraphQLClient.test.ts
+++ b/packages/graphql-hooks/test-node/GraphQLClient.test.ts
@@ -121,7 +121,7 @@ describe('with files in Node JS', () => {
       query: validQuery,
       operationName: 'Operation'
     }
-    
+
     const client = new GraphQLClient(validConfig)
     const mutationsEmitterMock = {
       ...new EventEmitter(),


### PR DESCRIPTION
### What does this PR do?

Converts an iterator to an array in a `memCache.keys()` method.

`tiny-lru` package did a breaking change in a patch release and the `lru.keys()` newly returns an iterator, not an array.

### Related issues

https://github.com/nearform/graphql-hooks/issues/1039

### Checklist

- [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation (note: I didn't have to)
- [x] I have added or updated any relevant tests (note: I didn't have to)
