### PR TITLE
fix: setQueryData not updating the UI

### DIFF
--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -42,7 +42,7 @@ function reducer(state, action) {
         ...state,
         loading: true
       }
-    case action.DATA_UPDATED:
+    case actionTypes.DATA_UPDATED:
       return {
         ...state,
         data: action.result.data

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -14,7 +14,8 @@ const actionTypes = {
   RESET_STATE: 'RESET_STATE',
   LOADING: 'LOADING',
   CACHE_HIT: 'CACHE_HIT',
-  REQUEST_RESULT: 'REQUEST_RESULT'
+  REQUEST_RESULT: 'REQUEST_RESULT',
+  DATA_UPDATED: 'DATA_UPDATED'
 }
 
 function reducer(state, action) {
@@ -40,6 +41,11 @@ function reducer(state, action) {
       return {
         ...state,
         loading: true
+      }
+    case action.DATA_UPDATED:
+      return {
+        ...state,
+        data: action.result.data
       }
     case actionTypes.CACHE_HIT:
       if (state.cacheHit && !action.resetState) {
@@ -293,7 +299,7 @@ function useClientRequest<
       handleEvents(payload, actionTypes.REQUEST_RESULT)
 
     const dataUpdatedCallback = payload =>
-      handleEvents(payload, actionTypes.CACHE_HIT)
+      handleEvents(payload, actionTypes.DATA_UPDATED)
 
     const mutationsEmitter = client.mutationsEmitter
     mutationsEmitter.on(Events.DATA_INVALIDATED, dataInvalidatedCallback)


### PR DESCRIPTION
### Fix `queryClient.setQueryData` not updating UI on multiple calls

Am try to do Optimistic Updates, after some mutations. What happens is after I do the mutations and I call `setQueryData`, for the first time it works, but subsequent calls to `setQueryData`, do not seem to work. 

From the source code I have seen DATA_UPDATED event is being handle by CACHE_HIT reducer, which updates the state conditionally (Am not sure even why the first call to `setQueryData` works because this condition is never meet when DATA_UPDATE event is fired).
So what I have just done is added another reducer that will handle DATA_UPDATED  and it always update the state data

Related issues
Closes https://github.com/nearform/graphql-hooks/issues/1065

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests

