### PR TITLE
chore: update rollup plugin packages

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,9 +1,9 @@
 import path from 'path'
-import nodeResolve from 'rollup-plugin-node-resolve'
-import babel from 'rollup-plugin-babel'
+import nodeResolve from '@rollup/plugin-node-resolve'
+import babel from '@rollup/plugin-babel'
 import replace from 'rollup-plugin-replace'
-import commonjs from 'rollup-plugin-commonjs'
-import { terser } from 'rollup-plugin-terser'
+import commonjs from '@rollup/plugin-commonjs'
+import terser from '@rollup/plugin-terser'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 
@@ -42,9 +42,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       external,
       plugins: [
         commonjs(),
-        nodeResolve({
-          jsnext: true
-        }),
+        nodeResolve(),
         esbuild(),
         replace({
           'process.env.NODE_ENV': JSON.stringify('production')
@@ -74,9 +72,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       external,
       plugins: [
         commonjs(),
-        nodeResolve({
-          jsnext: true
-        }),
+        nodeResolve(),
         esbuild(),
         babel({
           exclude: 'node_modules/**'
@@ -101,9 +97,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       external,
       plugins: [
         commonjs(),
-        nodeResolve({
-          jsnext: true
-        }),
+        nodeResolve(),
         esbuild(),
         babel({
           exclude: 'node_modules/**'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "@babel/preset-typescript": "^7.18.6",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
     "@testing-library/cypress": "^9.0.0",
     "@types/jest": "^29.0.3",
     "babel-jest": "^29.0.1",
@@ -46,13 +50,9 @@
     "lint-staged": "^14.0.1",
     "prettier": "^2.7.1",
     "rollup": "^2.47.0",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-esbuild": "^5.0.0",
-    "rollup-plugin-node-resolve": "^5.0.2",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
-    "rollup-plugin-terser": "^7.0.0",
     "ts-jest": "^29.0.1",
     "typescript": "^4.9.5"
   },
@@ -63,7 +63,7 @@
     ]
   },
   "engines": {
-    "node": "^16"
+    "node": ">=16"
   },
   "workspaces": [
     "packages/*",

--- a/packages/graphql-hooks-memcache/rollup.config.js
+++ b/packages/graphql-hooks-memcache/rollup.config.js
@@ -1,6 +1,6 @@
-import nodeResolve from 'rollup-plugin-node-resolve'
-import babel from 'rollup-plugin-babel'
-import commonjs from 'rollup-plugin-commonjs'
+import nodeResolve from '@rollup/plugin-node-resolve'
+import babel from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 import generateRollupConfig from '../../config/rollup.config'

--- a/packages/graphql-hooks/rollup.config.js
+++ b/packages/graphql-hooks/rollup.config.js
@@ -1,4 +1,4 @@
-import babel from 'rollup-plugin-babel'
+import babel from '@rollup/plugin-babel'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 


### PR DESCRIPTION
### What does this PR do?

We were still using a lot of deprecated rollup plugins. This MR updates the references to the affected plugins. This also fixes some issues we were seeing with builds failing. 

### Related issues

Resolves #1146

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
