### PR TITLE
chore: correct graphql-hooks release version

### DIFF
--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-hooks",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Graphql Hooks",
   "main": "lib/graphql-hooks.js",
   "module": "es/graphql-hooks.js",


### PR DESCRIPTION
### What does this PR do?

- correct the release version of the graphql-hooks lib 

### Related issues

Closes #1153

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
