### PR TITLE
chore(deps-dev): bump lerna from 7.4.2 to 8.1.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,6 @@
       "conventionalCommits": true,
       "createRelease": "github"
     }
-  }
+  },
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jest": "^29.0.1",
     "jest-environment-jsdom": "^29.0.1",
     "jest-environment-node": "^29.0.1",
-    "lerna": "^7.0.1",
+    "lerna": "^8.1.2",
     "lint-staged": "^15.2.0",
     "prettier": "^2.7.1",
     "rollup": "^2.47.0",


### PR DESCRIPTION
### What does this PR do?

Bumps lerna from 7.4.2 to 8.1.2
### Related issues

[Dependabot change](https://github.com/nearform/graphql-hooks/pull/1162)

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests

@all-contributors please add @edge33 for maintenance