### PR TITLE
feat!: exclude client mutations from refetch condition

### DIFF
--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -61,7 +61,7 @@ function useQuery<
     setCalledDuringSSR(true)
   }
 
-  const { client, allOptsToStringify } = allOpts
+  const { client: clientFromOpts, allOptsToStringify } = allOpts
   const stringifiedAllOpts = JSON.stringify(allOptsToStringify)
   React.useEffect(() => {
     if (allOpts.skip) {

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -61,7 +61,8 @@ function useQuery<
     setCalledDuringSSR(true)
   }
 
-  const stringifiedAllOpts = JSON.stringify(allOpts)
+  const { client, allOptsToStringify } = allOpts
+  const stringifiedAllOpts = JSON.stringify(allOptsToStringify)
   React.useEffect(() => {
     if (allOpts.skip) {
       return

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -61,7 +61,7 @@ function useQuery<
     setCalledDuringSSR(true)
   }
 
-  const { client: clientFromOpts, allOptsToStringify } = allOpts
+  const { client: clientFromOpts, ...allOptsToStringify } = allOpts
   const stringifiedAllOpts = JSON.stringify(allOptsToStringify)
   React.useEffect(() => {
     if (allOpts.skip) {

--- a/packages/graphql-hooks/test-jsdom/unit/useQuery.test.tsx
+++ b/packages/graphql-hooks/test-jsdom/unit/useQuery.test.tsx
@@ -379,6 +379,17 @@ describe('useQuery', () => {
     expect(mockClient2.ssrPromises[0]).resolves.toBe('data')
   })
 
+  it('does not run when client headers change', () => {
+    const { rerender } = renderHook(() => useQuery(TEST_QUERY, { client: mockClient }), {
+      wrapper: Wrapper
+    })
+    mockClient.headers = {
+      trace_id: '123'
+    }
+    rerender()
+    expect(mockQueryReq).toHaveBeenCalledTimes(1)
+  })
+
   describe('skip option', () => {
     it('should skip query if `skip` is `true`', () => {
       const queryReqMock = jest.fn()


### PR DESCRIPTION
Client's own options can be changed by a middleware which makes useQuery repeat the call

### What does this PR do?

It excludes client from comparison with a previous value in order to make a decision if a re-fetch is needed. Example: a middleware applies additional headers for specific queries only and restores them back to initial set after the request is complete. This runs `useEffect` hook again and it becomes an infinite loop.

### Related issues

none
