### PR TITLE
fix: removed dependency on graphQL

### DIFF
--- a/examples/typescript/src/gql/fragment-masking.ts
+++ b/examples/typescript/src/gql/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { FragmentDefinitionNode } from 'graphql';
 import { Incremental } from './graphql';

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -33,12 +33,11 @@
   "author": "Brian Mullan <bmullan91@gmail.com>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "graphql": "^16.8.1",
     "react": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
+    "@0no-co/graphql.web": "^1.0.7",
     "@aws-crypto/sha256-browser": "^5.2.0",
-    "@graphql-typed-document-node/core": "^3.2.0",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "extract-files": "^11.0.0",

--- a/packages/graphql-hooks/src/createRefetchMutationsMap.ts
+++ b/packages/graphql-hooks/src/createRefetchMutationsMap.ts
@@ -1,4 +1,4 @@
-import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from './types/typedDocumentNode'
 
 import {
   RefetchAfterMutationItem,

--- a/packages/graphql-hooks/src/types/typedDocumentNode.ts
+++ b/packages/graphql-hooks/src/types/typedDocumentNode.ts
@@ -1,0 +1,19 @@
+import { DocumentNode } from '@0no-co/graphql.web'
+
+export interface DocumentTypeDecoration<TResult, TVariables> {
+  /**
+   * This type is used to ensure that the variables you pass in to the query are assignable to Variables
+   * and that the Result is assignable to whatever you pass your result to. The method is never actually
+   * implemented, but the type is valid because we list it as optional
+   */
+  __apiType?: (variables: TVariables) => TResult
+}
+export interface TypedDocumentNode<
+  TResult = {
+    [key: string]: any
+  },
+  TVariables = {
+    [key: string]: any
+  }
+> extends DocumentNode,
+    DocumentTypeDecoration<TResult, TVariables> {}

--- a/packages/graphql-hooks/src/useClientRequest.ts
+++ b/packages/graphql-hooks/src/useClientRequest.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import { TypedDocumentNode } from './types/typedDocumentNode'
 
 import ClientContext from './ClientContext'
 import { Events } from './events'

--- a/packages/graphql-hooks/src/useManualQuery.ts
+++ b/packages/graphql-hooks/src/useManualQuery.ts
@@ -1,4 +1,4 @@
-import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from './types/typedDocumentNode'
 
 import {
   FetchData,

--- a/packages/graphql-hooks/src/useMutation.ts
+++ b/packages/graphql-hooks/src/useMutation.ts
@@ -1,4 +1,4 @@
-import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from './types/typedDocumentNode'
 
 import useClientRequest from './useClientRequest'
 import {

--- a/packages/graphql-hooks/src/useQuery.ts
+++ b/packages/graphql-hooks/src/useQuery.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from './types/typedDocumentNode'
 
 import ClientContext from './ClientContext'
 import createRefetchMutationsMap from './createRefetchMutationsMap'

--- a/packages/graphql-hooks/src/utils.ts
+++ b/packages/graphql-hooks/src/utils.ts
@@ -2,7 +2,7 @@ import type {
   DocumentNode,
   OperationDefinitionNode
 } from 'graphql/language/ast'
-import { Kind, print } from 'graphql'
+import { Kind, print } from '@0no-co/graphql.web'
 
 /**
  * Pipe with support for async functions


### PR DESCRIPTION
### What does this PR do?

Removed the peer dependency graphql
Added dependency on @0no-co/graphql.web
Moved typedDocumentNode to inside project (dependency on DocumentNode which is imported fromno-co/graphqlinstead of graphql


### Related issues

closes https://github.com/nearform/graphql-hooks/issues/1177

### Checklist

- [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
