### PR TITLE
fix: return response reducer even if falsy

### DIFF
--- a/packages/graphql-hooks/src/GraphQLClient.ts
+++ b/packages/graphql-hooks/src/GraphQLClient.ts
@@ -350,10 +350,10 @@ class GraphQLClient {
               graphQLErrors: errors,
               data:
                 // enrich data with responseReducer if defined
-                (typeof options.responseReducer === 'function' &&
-                  options.responseReducer(data, response)) ||
-                data,
-              headers: response.headers,
+                typeof options.responseReducer === 'function'
+                  ? options.responseReducer(data, response)
+                  : data,
+              headers: response.headers
             })
           })
         }


### PR DESCRIPTION
### What does this PR do?

If a responseReducer was used respond with the result, even if falsy.

### Related issues

https://github.com/nearform/graphql-hooks/issues/1185

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
