### PR TITLE
docs: updated readMe with correct bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Features
 
 - 🥇 First-class hooks API
-- ⚖️ _Tiny_ bundle: only 7.6kB (2.8 gzipped)
+- ⚖️ _Tiny_ bundle: only 22.9kB (7.4kB gzipped)
 - 📄 Full SSR support: see [graphql-hooks-ssr](packages/graphql-hooks-ssr)
 - 🔌 Plugin Caching: see [graphql-hooks-memcache](packages/graphql-hooks-memcache)
 - 🔥 No more render props hell


### PR DESCRIPTION
### What does this PR do?

Updated readMe with correct size from bundlephobia

https://bundlephobia.com/package/graphql-hooks@8.0.0

### Related issues
 closes #1194

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
