### PR TITLE
Adding React 19.x to peerDependencies

### DIFF
--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -33,7 +33,7 @@
   "author": "Brian Mullan <bmullan91@gmail.com>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.7",


### PR DESCRIPTION
### What does this PR do?

Resolves a peer dependency error when installing the `graphql-hooks` package in a React 19.x project.

### Related issues

Fixes #1217 

### Checklist

- [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [ ] I have added or updated any relevant documentation
- [ ] I have added or updated any relevant tests
