### PR TITLE
chore(deps): consolidate Dependabot updates

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Install root
         run: npm install
       - name: Cypress create-react-app
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           browser: chrome
           install: false
           spec: cypress/e2e/create-react-app.cy.ts
           start: npm start --prefix ./examples/create-react-app
       - name: Cypress persisted-queries Mercurius
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           browser: chrome
           install: false
@@ -36,7 +36,7 @@ jobs:
           PORT: 3002
           CYPRESS_CLIENT_PORT: 3002
       - name: Cypress persisted-queries Apollo Server
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           spec: cypress/e2e/persisted-queries.cy.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('**/package.json') }}

--- a/examples/fastify-ssr/package.json
+++ b/examples/fastify-ssr/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.7.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.0.2"
+    "react-router-dom": "^7.9.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/examples/persisted-queries/client/package.json
+++ b/examples/persisted-queries/client/package.json
@@ -12,7 +12,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.1.2"
+    "typescript": "^5.9.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/persisted-queries/server/package.json
+++ b/examples/persisted-queries/server/package.json
@@ -21,6 +21,6 @@
     "@tsconfig/node16": "^16.1.0",
     "@types/node": "^22.10.5",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.7.4"
+    "typescript": "^5.9.0"
   }
 }

--- a/examples/subscription/package.json
+++ b/examples/subscription/package.json
@@ -24,7 +24,7 @@
     "graphql-hooks-memcache": "^3.2.0",
     "lowdb": "^7.0.1",
     "mercurius": "^14.0.0",
-    "mqemitter-redis": "^5.0.0",
+    "mqemitter-redis": "^7.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "subscriptions-transport-ws": "^0.11.0"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@types/jest": "^29.0.3",
     "@types/node": "^22.10.5",
-    "@types/react": "^18.0.0",
+    "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.2",
     "graphql-hooks": "^8.2.0",
     "graphql-hooks-memcache": "^3.2.0",
@@ -38,6 +38,6 @@
     "@graphql-codegen/client-preset": "^4.1.0",
     "graphql": "^16.8.1",
     "graphql-codegen-typescript-client": "0.18.2",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.18.6",
-    "@commitlint/cli": "^19.3.0",
+    "@commitlint/cli": "^20.2.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,12 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "ts-jest": "^29.0.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9.0"
+  },
+  "overrides": {
+    "react-scripts": {
+      "typescript": "^5.9.0"
+    }
   },
   "lint-staged": {
     "**/*.js": [

--- a/packages/babel-plugin-extract-gql/package.json
+++ b/packages/babel-plugin-extract-gql/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fastify/cors": "^9.0.1",
     "fastify": "^4.2.0",
-    "pkg-dir": "^8.0.0"
+    "pkg-dir": "^9.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Consolidates the open Dependabot PRs listed below into a single reviewable change, **plus the TypeScript bump
required to make CI run at all** (see "Repairing the build" below).

This repo sets `package-lock=false` in `.npmrc`, so there is no lockfile to regenerate —
each bump is a manifest edit, re-derived on top of `master` rather than merged from the
Dependabot branches.

Closes #1265

## Included updates

| Package | From | To | Bump | Ecosystem | Supersedes |
|---------|------|----|------|-----------|------------|
| `cypress-io/github-action` | 6 | 7 | major | github_actions | #1261 |
| `actions/cache` | 3 | 5 | major | github_actions | #1260 |
| `@commitlint/cli` | 19.3.0 | 20.2.0 | major | npm | #1256 |
| `react-router-dom` | 6.0.2 | 7.9.6 | major | npm | #1255 |
| `pkg-dir` | 8.0.0 | 9.0.0 | major | npm | #1253 |
| `mqemitter-redis` | 5.0.0 | 7.2.0 | major | npm | #1252 |
| `typescript` | 4.9.5 | 5.9.0 | major | npm | — (build repair, see below) |

## Repairing the build

CI was red on this PR — and on `master` — **before it ran anything**. Both jobs died at the `npm install` step and
every subsequent step was reported as *skipped*, so CI never evaluated the consolidated bumps at all.

`npm install` triggers `postinstall` → `build:packages` → `graphql-hooks:build` → `build:types`, and that last step
failed:

```
../../node_modules/@types/node/ffi.d.ts(260,9):  error TS1109: Expression expected.
../../node_modules/@types/node/ffi.d.ts(260,10): error TS1128: Declaration or statement expected.
../../node_modules/@types/node/ffi.d.ts(273,35): error TS1005: ',' expected.
```

With no lockfile, `@types/node` floats and has drifted to a version whose `.d.ts` files `typescript@4.9.5` (Nov 2022)
cannot **parse**. These are syntax errors, so the `skipLibCheck: true` already set in `config/tsconfig.base.json` does
not suppress them, and `packages/graphql-hooks/tsconfig.json` declares no `types` array — so `tsc` auto-loads the
drifted `@types/node` into the declaration emit. Full analysis in #1265.

Fixing this is a prerequisite for the rest of the PR being testable, so it is folded in here:

- **`typescript` → `^5.9.0`** at the root and in `examples/typescript`, `examples/persisted-queries/server`
  (`^4.7.4`) and `examples/persisted-queries/client` (`^4.1.2`). The server one is not cosmetic — its `ts-node-dev`
  type-checks at boot and it is the server the `acceptance-tests` job starts.
- Pins stay inside the **5.x** line deliberately: TypeScript 6 drops `moduleResolution: "node"`, which
  `config/tsconfig.base.json` still uses.

Two pre-existing problems were masked behind the install failure and surfaced only once it was fixed. Both are
repaired here:

- `react-scripts@5.0.1` declares `peerOptional typescript@"^3.2.1 || ^4"`, so npm `ERESOLVE`s against TS 5. CRA is
  unmaintained, so this is relaxed with an `overrides` entry rather than an upstream bump.
- `examples/typescript` pinned `@types/react@^18` while using `react@^19` and `@types/react-dom@^19`. The two copies
  of `@types/react` in the tree produced `TS2786: 'ClientContext.Provider' cannot be used as a JSX component`
  (`Type 'bigint' is not assignable to type 'ReactNode'`). Aligned to `^19`, matching every other workspace.

`packages/graphql-hooks/src` needed **no** source changes — `check-types` passes clean under 5.9.

### Considered and rejected

Adding `"types": []` to `packages/graphql-hooks/tsconfig.json` would also stop `@types/node` being auto-loaded, but
`src/GraphQLClient.ts` does `import EventEmitter from 'events'` and the npm `events@3.3.0` package ships no `.d.ts` —
that import resolves *through* `@types/node`'s `declare module "events"`. Dropping node types yields
`TS2307: Cannot find module 'events'`, which `noImplicitAny: false` does not suppress.

## Verification

Run locally with the CI toolchain — Node 24.18.0 (`.nvmrc` → `lts/*`) — from a clean tree, following the exact
`ci.yml` step sequence:

| Step | Result |
|------|--------|
| `npm install` (incl. `postinstall` → `build:packages`) | ✅ — the step that had been failing |
| `npm run lint` | ✅ |
| `npm run test:coverage -- --silent` | ✅ 225/225, 23 suites |
| `npm run check-types` | ✅ |
| `npm run build` (full, all 8 projects) | ✅ |

The acceptance path CI had never reached was also exercised locally:

| Check | Result |
|-------|--------|
| `start:mercurius` boots (`ts-node-dev` type-checks) | ✅ on `typescript@5.9.3` |
| `start:apollo` boots | ✅ on `typescript@5.9.3` |
| `cypress run --spec cypress/e2e/persisted-queries.cy.ts` | ✅ 1/1 |
| `cypress run --spec cypress/e2e/create-react-app.cy.ts` | ✅ 1/1 |

Note that CI is the first thing to actually exercise the `cypress-io/github-action@v6 → v7` bump — the local runs
above invoke Cypress directly, not through the action.

## Moved to a follow-up PR

- #1254 `jest` 29.0.1 → 30.2.0 and `@types/jest` → 30 — jest 30 removes deprecated matcher
  aliases and its jsdom 26 environment makes `window` non-configurable, which breaks an SSR
  test. Needs a real migration decision, so it is split out rather than forced in here → **#1264**.

## Not addressed here

Reintroducing a lockfile. It is the systemic cure for this class of breakage — without one, the repo went red with
no commit pushed, and it stayed unnoticed for roughly eight months. But `package-lock=false` is a deliberate
maintainer policy choice, so it is raised in #1265 rather than changed in a dependency-consolidation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
