### PR TITLE
chore(deps): consolidate Dependabot updates

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -10,8 +10,8 @@ jobs:
   acceptance-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
       - name: Install root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Cache node modules
         uses: actions/cache@v5
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('**/package.json') }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
       - run: npm install
@@ -25,6 +25,6 @@ jobs:
       - run: npm run test:coverage -- --silent
       - run: npm run check-types
       - run: npm run build
-      - uses: coverallsapp/github-action@v2.3.7
+      - uses: coverallsapp/github-action@v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Cache node modules
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/create-react-app-server.yml
+++ b/.github/workflows/create-react-app-server.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -17,6 +17,6 @@ jobs:
       contents: read
     steps:
       - name: Notify release
-        uses: nearform-actions/github-action-notify-release@v1
+        uses: nearform-actions/github-action-notify-release@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,4 +8,4 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -34,8 +34,8 @@
     ]
   },
   "devDependencies": {
-    "@graphql-codegen/cli": "^5.0.0",
-    "@graphql-codegen/client-preset": "^4.1.0",
+    "@graphql-codegen/cli": "^7.3.0",
+    "@graphql-codegen/client-preset": "^6.1.3",
     "graphql": "^16.8.1",
     "graphql-codegen-typescript-client": "0.18.2",
     "typescript": "^5.9.0"

--- a/examples/typescript/src/gql/fragment-masking.ts
+++ b/examples/typescript/src/gql/fragment-masking.ts
@@ -9,33 +9,53 @@ import { Incremental } from './graphql'
 
 export type FragmentType<
   TDocumentType extends DocumentTypeDecoration<any, any>
-> = TDocumentType extends DocumentTypeDecoration<infer TType, any>
-  ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
-    ? TKey extends string
-      ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
+> =
+  TDocumentType extends DocumentTypeDecoration<infer TType, any>
+    ? [TType] extends [{ ' $fragmentName'?: infer TKey }]
+      ? TKey extends string
+        ? { ' $fragmentRefs'?: { [key in TKey]: TType } }
+        : never
       : never
     : never
-  : never
 
 // return non-nullable if `fragmentType` is non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>
 ): TType
+// return nullable if `fragmentType` is undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined
+): TType | undefined
 // return nullable if `fragmentType` is nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null
+): TType | null
+// return nullable if `fragmentType` is nullable or undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType:
-    | FragmentType<DocumentTypeDecoration<TType, any>>
-    | null
-    | undefined
+    FragmentType<DocumentTypeDecoration<TType, any>> | null | undefined
 ): TType | null | undefined
 // return array of non-nullable if `fragmentType` is array of non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+): Array<TType>
+// return array of nullable if `fragmentType` is array of nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType:
+    Array<FragmentType<DocumentTypeDecoration<TType, any>>> | null | undefined
+): Array<TType> | null | undefined
+// return readonly array of non-nullable if `fragmentType` is array of non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
 ): ReadonlyArray<TType>
-// return array of nullable if `fragmentType` is array of nullable
+// return readonly array of nullable if `fragmentType` is array of nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType:
@@ -47,10 +67,11 @@ export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType:
     | FragmentType<DocumentTypeDecoration<TType, any>>
+    | Array<FragmentType<DocumentTypeDecoration<TType, any>>>
     | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
     | null
     | undefined
-): TType | ReadonlyArray<TType> | null | undefined {
+): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
   return fragmentType as any
 }
 
@@ -64,9 +85,7 @@ export function isFragmentReady<TQuery, TFrag>(
   queryNode: DocumentTypeDecoration<TQuery, any>,
   fragmentNode: TypedDocumentNode<TFrag>,
   data:
-    | FragmentType<TypedDocumentNode<Incremental<TFrag>, any>>
-    | null
-    | undefined
+    FragmentType<TypedDocumentNode<Incremental<TFrag>, any>> | null | undefined
 ): data is FragmentType<typeof fragmentNode> {
   const deferredFields = (
     queryNode as {
@@ -77,8 +96,7 @@ export function isFragmentReady<TQuery, TFrag>(
   if (!deferredFields) return true
 
   const fragDef = fragmentNode.definitions[0] as
-    | FragmentDefinitionNode
-    | undefined
+    FragmentDefinitionNode | undefined
   const fragName = fragDef?.name?.value
 
   const fields = (fragName && deferredFields[fragName]) || []

--- a/examples/typescript/src/gql/gql.ts
+++ b/examples/typescript/src/gql/gql.ts
@@ -11,8 +11,14 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * 3. It does not support dead code elimination, so it will add unused operations.
  *
  * Therefore it is highly recommended to use the babel or swc plugin for production.
+ * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
-const documents = {
+type Documents = {
+  '\n  query GetAllPosts {\n    allPosts {\n      id\n      title\n      url\n    }\n  }\n': typeof types.GetAllPostsDocument
+  '\n  mutation CreatePost($title: String!, $url: String!) {\n    createPost(title: $title, url: $url) {\n      id\n    }\n  }\n': typeof types.CreatePostDocument
+  '\n  query Post($id: ID!) {\n    Post(id: $id) {\n      id\n      url\n      title\n    }\n  }\n': typeof types.PostDocument
+}
+const documents: Documents = {
   '\n  query GetAllPosts {\n    allPosts {\n      id\n      title\n      url\n    }\n  }\n':
     types.GetAllPostsDocument,
   '\n  mutation CreatePost($title: String!, $url: String!) {\n    createPost(title: $title, url: $url) {\n      id\n    }\n  }\n':

--- a/examples/typescript/src/gql/graphql.ts
+++ b/examples/typescript/src/gql/graphql.ts
@@ -1,143 +1,32 @@
 /* eslint-disable */
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
-export type Maybe<T> = T | null
-export type InputMaybe<T> = Maybe<T>
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K]
-}
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>
-}
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>
-}
-export type MakeEmpty<
-  T extends { [key: string]: unknown },
-  K extends keyof T
-> = { [_ in K]?: never }
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+/** Internal type. DO NOT USE DIRECTLY. */
 export type Incremental<T> =
   | T
   | {
       [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never
     }
-/** All built-in and custom scalars, mapped to their actual values */
-export type Scalars = {
-  ID: { input: string; output: string }
-  String: { input: string; output: string }
-  Boolean: { input: boolean; output: boolean }
-  Int: { input: number; output: number }
-  Float: { input: number; output: number }
-}
-
-export type ListMetadata = {
-  __typename?: 'ListMetadata'
-  count?: Maybe<Scalars['Int']['output']>
-}
-
-export type Mutation = {
-  __typename?: 'Mutation'
-  createManyPost?: Maybe<Array<Maybe<Post>>>
-  createPost?: Maybe<Post>
-  removePost?: Maybe<Post>
-  updatePost?: Maybe<Post>
-}
-
-export type MutationCreateManyPostArgs = {
-  data?: InputMaybe<Array<InputMaybe<PostInput>>>
-}
-
-export type MutationCreatePostArgs = {
-  title: Scalars['String']['input']
-  url: Scalars['String']['input']
-}
-
-export type MutationRemovePostArgs = {
-  id: Scalars['ID']['input']
-}
-
-export type MutationUpdatePostArgs = {
-  id: Scalars['ID']['input']
-  title?: InputMaybe<Scalars['String']['input']>
-  url?: InputMaybe<Scalars['String']['input']>
-}
-
-export type Post = {
-  __typename?: 'Post'
-  id: Scalars['ID']['output']
-  title: Scalars['String']['output']
-  url: Scalars['String']['output']
-}
-
-export type PostFilter = {
-  id?: InputMaybe<Scalars['ID']['input']>
-  id_neq?: InputMaybe<Scalars['ID']['input']>
-  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
-  q?: InputMaybe<Scalars['String']['input']>
-  title?: InputMaybe<Scalars['String']['input']>
-  title_neq?: InputMaybe<Scalars['String']['input']>
-  url?: InputMaybe<Scalars['String']['input']>
-  url_neq?: InputMaybe<Scalars['String']['input']>
-}
-
-export type PostInput = {
-  title: Scalars['String']['input']
-  url: Scalars['String']['input']
-}
-
-export type Query = {
-  __typename?: 'Query'
-  Post?: Maybe<Post>
-  _allPostsMeta?: Maybe<ListMetadata>
-  allPosts?: Maybe<Array<Maybe<Post>>>
-}
-
-export type QueryPostArgs = {
-  id: Scalars['ID']['input']
-}
-
-export type Query_AllPostsMetaArgs = {
-  filter?: InputMaybe<PostFilter>
-  page?: InputMaybe<Scalars['Int']['input']>
-  perPage?: InputMaybe<Scalars['Int']['input']>
-}
-
-export type QueryAllPostsArgs = {
-  filter?: InputMaybe<PostFilter>
-  page?: InputMaybe<Scalars['Int']['input']>
-  perPage?: InputMaybe<Scalars['Int']['input']>
-  sortField?: InputMaybe<Scalars['String']['input']>
-  sortOrder?: InputMaybe<Scalars['String']['input']>
-}
-
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
 export type GetAllPostsQueryVariables = Exact<{ [key: string]: never }>
 
 export type GetAllPostsQuery = {
-  __typename?: 'Query'
-  allPosts?: Array<{
-    __typename?: 'Post'
-    id: string
-    title: string
-    url: string
-  } | null> | null
+  allPosts: Array<{ id: string; title: string; url: string } | null> | null
 }
 
 export type CreatePostMutationVariables = Exact<{
-  title: Scalars['String']['input']
-  url: Scalars['String']['input']
+  title: string
+  url: string
 }>
 
-export type CreatePostMutation = {
-  __typename?: 'Mutation'
-  createPost?: { __typename?: 'Post'; id: string } | null
-}
+export type CreatePostMutation = { createPost: { id: string } | null }
 
 export type PostQueryVariables = Exact<{
-  id: Scalars['ID']['input']
+  id: string | number
 }>
 
 export type PostQuery = {
-  __typename?: 'Query'
-  Post?: { __typename?: 'Post'; id: string; url: string; title: string } | null
+  Post: { id: string; url: string; title: string } | null
 }
 
 export const GetAllPostsDocument = {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cypress": "^13.11.0",
     "esbuild": "^0.23.1",
     "eslint": "^8.7.0",
-    "eslint-config-prettier": "^9.0.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-config-react-app": "^7.0.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@commitlint/cli": "^20.2.0",
     "@commitlint/config-conventional": "^19.2.2",
-    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",

--- a/packages/graphql-hooks/package.json
+++ b/packages/graphql-hooks/package.json
@@ -53,7 +53,7 @@
     "graphql-hooks-ssr": "^3.0.1",
     "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.5.5",
-    "jest-fetch-mock": "^3.0.0",
+    "jest-fetch-mock": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-test-renderer": "^19.0.0",

--- a/packages/graphql-hooks/test-jsdom/setup.js
+++ b/packages/graphql-hooks/test-jsdom/setup.js
@@ -1,4 +1,15 @@
-global.fetch = require('jest-fetch-mock')
+// jest-fetch-mock 4 no longer installs its globals as a side effect of being
+// required. enableMocks() is the documented entry point and sets `fetch`,
+// `Headers`, `Request` and `Response` from the same implementation, which keeps
+// `expect.any(Headers)` matching what the mocked responses actually carry.
+require('jest-fetch-mock').enableMocks()
+
+// ...and make the same implementation's classes the globals the tests compare
+// against. Under jsdom, `Headers` would otherwise resolve to the environment's
+// own class while the mocked responses carry cross-fetch's, so
+// `expect.any(Headers)` never matches.
+const { Headers, Request, Response } = require('cross-fetch')
+Object.assign(global, { Headers, Request, Response })
 
 if (typeof global.TextEncoder === 'undefined') {
   const { TextEncoder } = require('util')

--- a/packages/graphql-hooks/test-jsdom/setup.js
+++ b/packages/graphql-hooks/test-jsdom/setup.js
@@ -1,15 +1,13 @@
 // jest-fetch-mock 4 no longer installs its globals as a side effect of being
-// required. enableMocks() is the documented entry point and sets `fetch`,
-// `Headers`, `Request` and `Response` from the same implementation, which keeps
-// `expect.any(Headers)` matching what the mocked responses actually carry.
-require('jest-fetch-mock').enableMocks()
+// required; enableMocks() is the documented entry point.
+const fetchMock = require('jest-fetch-mock')
+fetchMock.enableMocks()
 
-// ...and make the same implementation's classes the globals the tests compare
-// against. Under jsdom, `Headers` would otherwise resolve to the environment's
-// own class while the mocked responses carry cross-fetch's, so
-// `expect.any(Headers)` never matches.
-const { Headers, Request, Response } = require('cross-fetch')
-Object.assign(global, { Headers, Request, Response })
+// enableMocks() only fills globals that are undefined, and jsdom already defines
+// its own `Headers` — so the mocked responses carry the mock's class while
+// `expect.any(Headers)` would resolve to jsdom's, and `instanceof` never
+// matches. Align the global with the class actually in use.
+global.Headers = fetchMock.Headers
 
 if (typeof global.TextEncoder === 'undefined') {
   const { TextEncoder } = require('util')


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single reviewable change.

Closes #1276

Supersedes #1283, #1281, #1280 (opened since this PR went up) and #1275, #1273, #1271, #1270,
#1269, #1268, #1267 (already closed against the first round of this branch).

## Included updates

| Ecosystem | Package | From | To | Bump | Supersedes | Status |
|---|---|---|---|---|---|---|
| npm | `@rollup/plugin-babel` | `^6.0.4` | `^7.1.0` | major | #1275 | ✅ pass |
| npm | `jest-fetch-mock` | `^3.0.0` | `^4.2.0` | major | #1273 | ✅ pass |
| npm | `eslint-config-prettier` | `^9.0.0` | `^10.1.8` | major | #1281 | ✅ pass |
| npm | `@graphql-codegen/cli` | `^5.0.0` | `^7.3.0` | major | #1283 | ✅ pass |
| npm | `@graphql-codegen/client-preset` | `^4.1.0` | `^6.1.3` | major | — (sibling, see below) | ✅ pass |
| github-actions | `actions/checkout` | 6 | 7 | major | #1269 | ✅ pass |
| github-actions | `actions/setup-node` | 6 | 7 | major | #1268 | ✅ pass |
| github-actions | `actions/cache` | 5 | 6 | major | #1280 | ✅ pass |
| github-actions | `actions/stale` | 10 | 11 | major | #1267 | ✅ tag + inputs ¹ |
| github-actions | `coverallsapp/github-action` | 2.3.7 | 2.3.8 | patch | #1270 | ✅ pass |
| github-actions | `nearform-actions/github-action-notify-release` | 1 | 2 | major | #1271 | ✅ tag + inputs ¹ |

¹ `stale.yml` and `notify-release.yml` are schedule/dispatch-only, so no PR run exercises them; see Verification.

`@graphql-codegen/cli` installs as **7.3.1**, one patch above the 7.3.0 Dependabot asked for —
`^7.3.0` admits it and there is no root lockfile to pin, so that is what the range resolves to today.

**`@graphql-codegen/client-preset` is a sibling Dependabot did not propose, and without it the
cli bump is a lie in the manifest.** cli 7 depends on `client-preset ^6.1.3` itself, so with the
declared `^4.1.0` left in place both majors install and the *nested* v6 is what `preset: 'client'`
actually runs — the declared v4 never executes:

```
└─┬ typescript-example@5.1.1
  ├─┬ @graphql-codegen/cli@7.3.1
  │ └── @graphql-codegen/client-preset@6.1.3   <- this one runs
  └── @graphql-codegen/client-preset@4.8.3     <- declared, inert
```

Declaring `^6.1.3` collapses that to one deduped copy, which is also the one the cli resolves.

## `jest-fetch-mock` 4 needed a setup migration

This is the only source change in the PR, and it is confined to
`packages/graphql-hooks/test-jsdom/setup.js`.

v4 no longer installs its globals as a side effect of being required, so the v3 idiom
`global.fetch = require('jest-fetch-mock')` leaves the environment half-configured. The visible
symptom was **5 failed suites**, all on the same assertion shape:

```
- Expected  -  1
+ Received  + 16

-   "headers": Any<Headers>,
+   "headers": Headers {
+     "append": [Function append],
```

`enableMocks()` is v4's documented entry point, but it only fills globals that are `undefined`,
and jsdom already defines its own `Headers`. So the mocked responses carry the mock's `Headers`
while `expect.any(Headers)` resolves to jsdom's — two different constructors, and `instanceof`
never matches. `enableMocks()` alone takes the suite from 5 failing suites to 3 (6 tests), which
is the halfway state worth recording because it looks like a fix.

The fix aligns that one global with the class actually in use, taken from the mock itself:

```js
const fetchMock = require('jest-fetch-mock')
fetchMock.enableMocks()
global.Headers = fetchMock.Headers
```

`Request` and `Response` need no assignment — jsdom defines neither, so `enableMocks()` installs
both already. Note `fetchMock.Response` is a plain wrapper function rather than a class, so it is
*not* a drop-in for the `new Response()` calls in `test-jsdom/utils.ts` and
`src/LocalGraphQLClient.ts`; only `Headers` should be overridden here.

## The new npm majors, checked past "lint and build are green"

**`eslint-config-prettier` 9 → 10** is behaviourally inert here. Comparing the *resolved* config
(`eslint --print-config packages/graphql-hooks/src/index.ts`) on both branches: **no rule present
on `master` is missing or changed on this branch** — 180 additions, 0 removals, 0 changes, and all
180 are `@stylistic/*` entries set to `off` (v10 covers that plugin too; this repo does not use
it). `eslint .` traverses **66 files with 0 errors and 0 warnings on both trees**, and a probe file
with a duplicate key, an unused variable, an undefined global and bad formatting reports the same
four errors on both:

```
1:21  error  Duplicate key 'a'                                no-dupe-keys
2:5   error  'unused' is assigned a value but never used      no-unused-vars
3:12  error  Replace `··)·{···return···` with `)·{⏎··return`  prettier/prettier
5:13  error  'undefinedGlobalHere' is not defined             no-undef
```

The `.eslintrc.js` `extends: ['prettier', ...]` entry still resolves because v10 kept `.` →
`index.js` in its `exports` map — it *added* `./flat`, it did not move the default.

**The codegen bump is not exercised by CI**, so it was run by hand:
`npm run generate-schema --prefix examples/typescript` succeeds against the live schema the example
points at, and `tsc --noEmit` in `examples/typescript` passes both before and after regenerating.

It does change what gets generated, and the change comes from `client-preset` 4 → 6 rather than
from the cli itself. Two parts to it: the schema-wide types (`Scalars`, `Maybe`, `Mutation`,
`Post`, …) are no longer emitted, only what the documents reach; and the operation result types
lose `__typename` and become non-optional:

```ts
- export type GetAllPostsQuery = { __typename?: 'Query', allPosts?: Array<{ __typename?: 'Post', id: string, … } | null> | null };
+ export type GetAllPostsQuery = { allPosts: Array<{ id: string, title: string, url: string } | null> | null };
```

`src/App.tsx` imports only `graphql` and `GetAllPostsQuery`, both still emitted, which is why the
typecheck holds.

**The tracked `examples/typescript/src/gql/*` files are regenerated here rather than left behind**
(3 files, +50/−137, then `prettier --write` to match how they were committed). `prestart` runs
codegen, so leaving them would mean the next `npm start` on that example silently dirties three
tracked files. Note this is *not* schema drift being swept in: regenerating with the old cli 5 on
`master` reproduces the committed types field-for-field, so the entire diff is the preset's own
output change.

## What `npm install` re-resolved

There is **no root lockfile** — `.npmrc` sets `package-lock=false` and CI runs `npm install` — so
the diff is manifest edits only, but the installed tree moves by more than the manifest does. (One
lockfile *is* tracked, `examples/persisted-queries/server/package-lock.json`: `lockfileVersion 1`,
pinning `fastify@3.29.0`/`mercurius@9.5.0`, containing none of the bumped packages, and nothing
installs from it — the root `npm install` covers that workspace. Pre-existing, untouched here.)

Name-keyed comparison of the two installed trees (2009 → 2020 packages): **19 added, 8 removed, 63
changed**. The additions are all cli 7's `@inquirer/*` prompt stack; the removals are the
`@graphql-tools/prisma-loader → graphql-request/jose` chain cli 7 dropped. Of the 63 changed, all
but four are the codegen family and its transitive helpers. The four that are not:

- `workerpool` `+9.3.4` — a new dependency of `@rollup/plugin-babel` 7. Inert here: its `parallel`
  option is opt-in and all four rollup configs call `babel()` without it.
- `domexception` — 4.0.0 copy gone; `jest-fetch-mock` 4 dropped it (native since Node 17).
- `conventional-commits-filter` — 5.0.0 copy gone; it was *extraneous* in the baseline install
  (`npm ls --all` reports 1 problem on `master`, 0 here), not a real move.
- and the one that reaches outside the dependency tree of any bump:

```
lodash (hoisted root copy): 4.17.23 -> 4.18.1
```

`@graphql-codegen/plugin-helpers@5.1.1` declares `lodash: ~4.17.0` — the only declared lodash
range in `master`'s tree that excludes 4.18 — so cli 5 was pinning the hoisted copy for everyone.
cli 7's `plugin-helpers@7.2.1` drops that constraint and the root copy floats up, taking nine
consumers with it (`cypress` `^4.17.21`, `html-webpack-plugin`, `workbox-build`, `inquirer`,
`whatwg-url` `^4.7.0`, `pretty-error`, `renderkid`, `async` `^4.17.14`, `eslint-plugin-flowtype`).
Every one of those ranges admits 4.18.1, so nothing resolves out of range — the one declarer that
*excludes* it, `graphql-toolkit@0.2.0`'s exact `4.17.11`, keeps its own nested copy in both trees,
which is why 4.17.11 still appears on both sides. It is still a real change, and the build/lint/test
evidence below is what covers it. `cypress` is the one consumer not covered locally;
`acceptance-tests` runs on this PR, and the `persisted-queries/client` bundle its specs load is
byte-identical to baseline.

Two smaller ones worth naming so they are not mistaken for regressions: `dotenv` loses its 16.6.1
copy (it came in via `prisma-loader`; `nx`'s 16.4.7 now hoists, and `dotenv-expand@11`'s `^16`
still resolves), and `jiti`'s three copies (1.21.7, 2.6.1, 2.7.0) are present in *both* trees with
only the hoist position swapped — a re-hoist, not a version change.

## Verification

Run on Node v24.18.0, reproducing every step `ci.yml` runs, with a `master` baseline (`f01cba2`)
taken first in a separate worktree. CI's `.nvmrc: lts/*` resolved to v24.19.0 on its last run —
the same 24.x LTS line.

| Step | `master` baseline | This branch |
|---|---|---|
| `npm install` (incl. `postinstall` → `build:packages`) | ✅ | ✅ |
| `npm run lint` | ✅ 66 files, 0 problems | ✅ 66 files, 0 problems |
| `npm run test:coverage -- --silent` | ✅ 225 passed, 23 suites | ✅ 225 passed, 23 suites |
| `npm run check-types` | ✅ | ✅ |
| `npm run build` | ✅ 8 projects | ✅ 8 projects |

The build emits real output, not just exit 0. `diff -rq` across all four package directories and
all five example build trees (`create-react-app`, `typescript`, `persisted-queries/client`,
`subscription`, `fastify-ssr` `build/`+`lib/`) reports **no differences other than the two source
files this PR edits** — `packages/graphql-hooks/package.json` and `test-jsdom/setup.js`. The two
CRA bundles are identical by md5 (`main.48ea776f.js` 293,168 B; `typescript-example`'s
`main.0984849f.js` too, which is the check that the regenerated types are type-only and change no
emit). The only other reported delta is inside three `.js.map` files, whose `file` field embeds a
per-invocation pre-rename hash.

**Not run locally:** `acceptance-tests.yml` (Cypress needs a browser) and the
`netlify/graphql-hooks-cra/deploy-preview` check (there is no `netlify.toml`, so its build command
is not in the tree). Both run on this PR. Three of the bumped workflows are not PR-triggered at all
and so are exercised by neither: `stale.yml` and `notify-release.yml` (schedule/`workflow_dispatch`
/release/issues) and `create-react-app-server.yml` (push to `master`). For those the check is that
the tag resolves and the action's inputs are unchanged — `stale@v11`, `notify-release@v2` and
`checkout@v7` are all "migrate to node24/ESM" releases, and `notify-release`'s `action.yml` takes
the same inputs as v1.

Because there is no lockfile, `npm install` re-resolves everything on every run, so the baseline
is the only way to attribute a failure — worth knowing for anyone reading a red build here later.

## Rebuilt on top of `master`

This branch was `BEHIND` after #1278 merged, so rather than rebase it was rebuilt: the previous
head re-applied onto `f01cba2`, then the new bumps added on top. Against the previously pushed head
(`954ad8b`) the delta is #1278's four files, the three new bumps, the regenerated
`examples/typescript/src/gql/*`, and one simplification of `test-jsdom/setup.js` — the earlier
version required `cross-fetch` directly, which no manifest in the repo declares (it is only
reachable as a hoisted transitive of `jest-fetch-mock`, and v4 treats it as a fallback), so it now
takes the class from the mock itself.

## Two bumps are **not** here, and stay open as their own trackers

Neither can be made green by work in this PR, so there is no draft follow-up — a draft is for a
bump that *could* land after migration, and both of these are gated on something else.

**#1274 `@babel/preset-env` 7.29.7 → 8.0.2 — blocked upstream.** preset-env 8 hard-peers
`@babel/core@^8`, and `@rollup/plugin-babel` peers `@babel/core@^7.0.0` at *every version ever
published* — 5.3.1, 6.0.0, 6.0.4, 6.1.0, 7.0.0 and 7.1.0, the last being the newest and the one
this PR takes. Any repo whose rollup build runs `babel()` cannot move to Babel 8 until that plugin
ships v8 support. Detail on the PR.

**#1282 `@fastify/static` → 10.1.3 — needs a coupled fastify 5 migration.** It declares no
`peerDependencies`, so it installs cleanly against this repo's `fastify: ^4.2.0` and CI stays
green; the constraint lives in its `fastify-plugin` metadata (`fastify: '5.x'`) and only fires when
the server boots, which CI never does for these two examples. Booting it locally:

```
@fastify/static@10.1.3 → FST_ERR_PLUGIN_VERSION_MISMATCH
  fastify-plugin: @fastify/static - expected '5.x' fastify version, '4.29.1' is installed
@fastify/static@7.0.4  → BOOT OK   (control)
```

Landing it means `fastify` 5 plus `@fastify/cors` ≥10 and `mercurius` ≥15 across
`examples/fastify-ssr` and `examples/subscription` — four coupled majors in two apps that CI does
not exercise, one of which needs Redis to boot at all. Detail on the PR.

## Known and accepted

Pre-existing conditions this PR does not touch, so nobody spends a review comment on them:

- `engines.node: ">=16"` in the root manifest is already contradicted on `master` by `jest@30`,
  `lerna`, `husky`, `lint-staged` and `@commitlint/cli` (all `>=18`). `jest-fetch-mock@4`'s
  `>=18` adds nothing new, and the root manifest is `private: true`.
- `examples/typescript` still declares `graphql-codegen-typescript-client@0.18.2` (2018), which
  nothing imports.
- `rollup-plugin-size-snapshot@0.12.0` remains unmaintained and peers `rollup ^2.0.0`.
