### PR TITLE
chore(deps): rollup-plugin-esbuild 6, with the esbuild target pinned

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -7,6 +7,12 @@ import terser from '@rollup/plugin-terser'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 
+// rollup-plugin-esbuild 5 defaulted to `target: 'es2017'`; 6 changed that default
+// to 'es2020'. Left implicit, the upgrade would silently raise the floor of the
+// published bundles by emitting untranspiled optional chaining. Pin the target so
+// the plugin's default can never move the output again.
+export const ESBUILD_TARGET = 'es2017'
+
 // get the package.json for the current package
 const packageDir = path.join(__filename, '..')
 const pkg = require(`${packageDir}/package.json`)
@@ -22,7 +28,12 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       input: entryPoint,
       output: { file: `lib/${pkg.name}.js`, format: 'cjs', indent: false },
       external,
-      plugins: [commonjs(), esbuild(), babel(), sizeSnapshot()],
+      plugins: [
+        commonjs(),
+        esbuild({ target: ESBUILD_TARGET }),
+        babel(),
+        sizeSnapshot()
+      ],
       ...overrides
     },
 
@@ -31,7 +42,12 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       input: entryPoint,
       output: { file: `es/${pkg.name}.js`, format: 'es', indent: false },
       external,
-      plugins: [commonjs(), esbuild(), babel(), sizeSnapshot()],
+      plugins: [
+        commonjs(),
+        esbuild({ target: ESBUILD_TARGET }),
+        babel(),
+        sizeSnapshot()
+      ],
       ...overrides
     },
 
@@ -43,7 +59,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       plugins: [
         commonjs(),
         nodeResolve(),
-        esbuild(),
+        esbuild({ target: ESBUILD_TARGET }),
         replace({
           'process.env.NODE_ENV': JSON.stringify('production')
         }),
@@ -73,7 +89,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       plugins: [
         commonjs(),
         nodeResolve(),
-        esbuild(),
+        esbuild({ target: ESBUILD_TARGET }),
         babel({
           exclude: 'node_modules/**'
         }),
@@ -98,7 +114,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       plugins: [
         commonjs(),
         nodeResolve(),
-        esbuild(),
+        esbuild({ target: ESBUILD_TARGET }),
         babel({
           exclude: 'node_modules/**'
         }),

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -7,11 +7,11 @@ import terser from '@rollup/plugin-terser'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 
-// rollup-plugin-esbuild 5 defaulted to `target: 'es2017'`; 6 changed that default
-// to 'es2020'. Left implicit, the upgrade would silently raise the floor of the
-// published bundles by emitting untranspiled optional chaining. Pin the target so
-// the plugin's default can never move the output again.
-export const ESBUILD_TARGET = 'es2017'
+// rollup-plugin-esbuild 5 defaulted to `target: 'es2017'`, 6 changed that
+// default to 'es2020'. Left implicit, the upgrade would silently raise the
+// floor of the published bundles by emitting untranspiled optional chaining.
+// Always build the plugin through here so the default cannot move the output.
+export const esbuildTs = () => esbuild({ target: 'es2017' })
 
 // get the package.json for the current package
 const packageDir = path.join(__filename, '..')
@@ -28,12 +28,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       input: entryPoint,
       output: { file: `lib/${pkg.name}.js`, format: 'cjs', indent: false },
       external,
-      plugins: [
-        commonjs(),
-        esbuild({ target: ESBUILD_TARGET }),
-        babel(),
-        sizeSnapshot()
-      ],
+      plugins: [commonjs(), esbuildTs(), babel(), sizeSnapshot()],
       ...overrides
     },
 
@@ -42,12 +37,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       input: entryPoint,
       output: { file: `es/${pkg.name}.js`, format: 'es', indent: false },
       external,
-      plugins: [
-        commonjs(),
-        esbuild({ target: ESBUILD_TARGET }),
-        babel(),
-        sizeSnapshot()
-      ],
+      plugins: [commonjs(), esbuildTs(), babel(), sizeSnapshot()],
       ...overrides
     },
 
@@ -59,7 +49,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       plugins: [
         commonjs(),
         nodeResolve(),
-        esbuild({ target: ESBUILD_TARGET }),
+        esbuildTs(),
         replace({
           'process.env.NODE_ENV': JSON.stringify('production')
         }),
@@ -89,7 +79,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       plugins: [
         commonjs(),
         nodeResolve(),
-        esbuild({ target: ESBUILD_TARGET }),
+        esbuildTs(),
         babel({
           exclude: 'node_modules/**'
         }),
@@ -114,7 +104,7 @@ const generateRollupConfig = ({ name, overrides, entryPoint }) => {
       plugins: [
         commonjs(),
         nodeResolve(),
-        esbuild({ target: ESBUILD_TARGET }),
+        esbuildTs(),
         babel({
           exclude: 'node_modules/**'
         }),

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint-staged": "^15.2.0",
     "prettier": "^3.5.3",
     "rollup": "^2.47.0",
-    "rollup-plugin-esbuild": "^5.0.0",
+    "rollup-plugin-esbuild": "^6.2.1",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "ts-jest": "^29.0.1",

--- a/packages/graphql-hooks-memcache/rollup.config.js
+++ b/packages/graphql-hooks-memcache/rollup.config.js
@@ -2,10 +2,7 @@ import nodeResolve from '@rollup/plugin-node-resolve'
 import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
-import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
-import generateRollupConfig, {
-  ESBUILD_TARGET
-} from '../../config/rollup.config'
+import generateRollupConfig, { esbuildTs } from '../../config/rollup.config'
 
 const pkg = require('./package.json')
 const externalPeerDeps = [...Object.keys(pkg.peerDependencies || {})]
@@ -17,7 +14,7 @@ const overrides = {
     nodeResolve({
       jsnext: true
     }),
-    esbuild({ target: ESBUILD_TARGET }),
+    esbuildTs(),
     babel(),
     sizeSnapshot()
   ]

--- a/packages/graphql-hooks-memcache/rollup.config.js
+++ b/packages/graphql-hooks-memcache/rollup.config.js
@@ -3,7 +3,9 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
-import generateRollupConfig from '../../config/rollup.config'
+import generateRollupConfig, {
+  ESBUILD_TARGET
+} from '../../config/rollup.config'
 
 const pkg = require('./package.json')
 const externalPeerDeps = [...Object.keys(pkg.peerDependencies || {})]
@@ -15,7 +17,7 @@ const overrides = {
     nodeResolve({
       jsnext: true
     }),
-    esbuild(),
+    esbuild({ target: ESBUILD_TARGET }),
     babel(),
     sizeSnapshot()
   ]

--- a/packages/graphql-hooks/rollup.config.js
+++ b/packages/graphql-hooks/rollup.config.js
@@ -1,10 +1,7 @@
 import babel from '@rollup/plugin-babel'
-import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 
-import generateRollupConfig, {
-  ESBUILD_TARGET
-} from '../../config/rollup.config'
+import generateRollupConfig, { esbuildTs } from '../../config/rollup.config'
 
 export default generateRollupConfig({
   name: 'GraphQLHooks',
@@ -16,5 +13,5 @@ export default generateRollupConfig({
     format: 'cjs',
     indent: false
   },
-  plugins: [esbuild({ target: ESBUILD_TARGET }), babel(), sizeSnapshot()]
+  plugins: [esbuildTs(), babel(), sizeSnapshot()]
 })

--- a/packages/graphql-hooks/rollup.config.js
+++ b/packages/graphql-hooks/rollup.config.js
@@ -2,7 +2,9 @@ import babel from '@rollup/plugin-babel'
 import esbuild from 'rollup-plugin-esbuild' // Used for TS transpiling
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 
-import generateRollupConfig from '../../config/rollup.config'
+import generateRollupConfig, {
+  ESBUILD_TARGET
+} from '../../config/rollup.config'
 
 export default generateRollupConfig({
   name: 'GraphQLHooks',
@@ -14,5 +16,5 @@ export default generateRollupConfig({
     format: 'cjs',
     indent: false
   },
-  plugins: [esbuild(), babel(), sizeSnapshot()]
+  plugins: [esbuild({ target: ESBUILD_TARGET }), babel(), sizeSnapshot()]
 })


### PR DESCRIPTION
Part of #1276. Supersedes #1272.

Closes #1279

This PR was previously a red-by-design draft holding the two bumps that could not land. It is now green and carries one of them properly. The other turned out to be blocked upstream, not merely unfinished — details below.

## `rollup-plugin-esbuild` 5.0.0 → 6.2.1 (#1272)

The bump is not a bare version change. `rollup-plugin-esbuild` moved its **default** `target` between majors:

| | default `target` |
|---|---|
| 5.x | `es2017` |
| 6.x | `es2020` |

None of the four rollup configs passed a `target`, so taking 6.x as-is would have **silently raised the floor of the published bundles**, emitting untranspiled optional chaining into `graphql-hooks`.

The reason that showed up as a hard failure instead of a quiet change is the diagnosis this PR corrects. `rollup-plugin-size-snapshot` vendors `terser@4.8.1`, which predates optional chaining and cannot parse it:

```
=== TERSER FAILED ===
error: SyntaxError: Unexpected token: punc (.)
line: 109 col: 46
offending source: "      operationName = operationDefinitions[0]?.name?.value;"
```

`terser.minify(source)` returns `{ error }` with no `.code`, so `minified.length` throws — which is the `TypeError: Cannot read properties of undefined (reading 'length')` at `rollup-plugin-size-snapshot/dist/index.js:80:30` that the earlier revision of this description reported. **The crash was a symptom of the target change, not an independent incompatibility**, so the previous conclusion — that the size-snapshot plugin had to be dropped or replaced, and that this was a maintainer decision about build tooling — was wrong.

### The fix

`config/rollup.config.js` exports `esbuildTs()` — the esbuild plugin with `target: 'es2017'` already applied — and all seven `esbuild()` call sites go through it:

- the upgrade becomes **behaviour-neutral**, and
- the plugin's default can never move the published output again — a new call site cannot
  reintroduce it by forgetting to pass a target, and
- the bundle-size report is **kept** — nothing is dropped, and no decision about build tooling is forced.

Changing the supported browser floor remains a separate, deliberate choice rather than a side effect of a dependency bump.

### Output equivalence

Built `master` (esbuild 5, default target) and this branch (esbuild 6, pinned target) and diffed all 34 emitted files:

- `graphql-hooks-memcache` — every bundle **byte-identical**
- all `.d.ts` — **identical**
- `graphql-hooks` — one difference: esbuild 6 no longer emits `__publicField(this, "…")` for the 15 declare-only class fields on `GraphQLClient` / `LocalGraphQLClient`

That last one is a correction, not a regression. This package compiles at `target: es2021` with `useDefineForClassFields` unset, where TypeScript's default is `false` — so `tsc` emits **no** pre-initialisation for a bare `url: string`, going straight to the constructor assignment. Confirmed by compiling the package with `tsc` directly: zero `defineProperty`/`void 0` field pre-inits. esbuild 5 was emitting define-semantics fields that `tsc` never would; 6 now matches `tsc`.

It is also unobservable at runtime. All 15 fields are assigned unconditionally in the constructor, so instantiating `GraphQLClient` from each build gives an identical own-key set, identical `in` results and identical spread:

```
ownKeyCount: 15   missingFromIn: []   spreadKeyCount: 15   // identical for both builds
```

## `@babel/preset-env` 7 → 8 (#1274) — reverted, blocked upstream

This bump is **not** included, and #1274 should stay open. The previous description framed it as migration work someone could sit down and do. It is not: there is a hard upstream wall.

`@babel/preset-env@8` peers `@babel/core@^8`. But **every version of `@rollup/plugin-babel` ever published — up to and including the current latest, 7.1.0 — peers `@babel/core@^7.0.0`**:

```
$ npm view @rollup/plugin-babel@7.1.0 peerDependencies
{ '@babel/core': '^7.0.0', … }
```

`@rollup/plugin-babel` is what builds all three published packages (6 `babel()` call sites across the four rollup configs), so `@babel/core` cannot move to 8 until that plugin ships Babel 8 support. No amount of work in this repo resolves it.

There is a second wall behind it, worth recording so it is not rediscovered:

- `@babel/eslint-parser@7.x` hard-peers `@babel/core@^7.11.0` — so it cannot come along to Babel 8, and
- `@babel/eslint-parser@8.x` peers `eslint@^9 || ^10` — so it needs the eslint 9/10 flat-config migration, which `eslint-config-react-app@7` blocks (it pins `@typescript-eslint` 5 and is still consumed by `examples/persisted-queries/client` and `examples/typescript` for `react-scripts build`).

Both were verified by attempting the migration; `npm install` fails with `ERESOLVE` in each direction. The one accurate item from the earlier description stands: `@babel/plugin-proposal-object-rest-spread` has no 8.x and must go when Babel 8 does land. It is left alone here — it is a full implementation, not a thin alias of `@babel/plugin-transform-object-rest-spread`, so swapping it is a behaviour change that belongs with the Babel 8 work rather than smuggled into this PR.

The `engines.node` point from the earlier description also turns out to be a non-issue: the root manifest is `private: true` and the published packages declare no `engines` at all, so a Babel 8 toolchain floor would never have reached consumers.

## Verification

Run on Node 24.18 (CI's `.nvmrc` `lts/*` resolves to 24.19):

| step | result |
|---|---|
| `npm install` | clean (this is what was failing — `ERESOLVE`, killing all four checks in ~8s) |
| `npm run lint` | 0 problems |
| `npm run test:coverage` | **225 passed**, 23 suites |
| `npm run check-types` | pass |
| `npm run build` | **8 of 8 projects**, including the CRA example netlify builds |

### Review follow-up

A second pass tightened this to the smallest diff that does the job (`54dc821`). The first revision exported the bare target string, which meant both package-level configs imported `rollup-plugin-esbuild` *and* the constant just to re-assemble the same call, two `plugins:` arrays reflowed past 80 columns, and a future call site could still call bare `esbuild()`. Exporting the pre-configured plugin instead removes all of that: 28 changed lines instead of 40, no formatting churn, and two fewer imports. Output is byte-identical across all 34 emitted files, so the change is verifiably behaviour-neutral.

Also confirmed in that pass: `rollup-plugin-esbuild@6` peers `esbuild >=0.18.0` and `rollup ^1||^2||^3||^4`, both already satisfied by the existing `esbuild@^0.23.1` and `rollup@^2.47.0`, so no sibling bump is needed.

Acceptance tests were not run locally — port 3000 was held by an unrelated process, and the spec hardcodes that URL. Their only failure was the shared `npm install` step, which now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

